### PR TITLE
2023 07 13 release

### DIFF
--- a/app-infrastructure/configs/httpd-vhosts.conf
+++ b/app-infrastructure/configs/httpd-vhosts.conf
@@ -63,8 +63,7 @@ ServerTokens Prod
     # unsafe-inline - Allows inline JavaScript, CSS, and event handlers
     # style-src - Allows inline styles but only from the same origin
     # img-src - Allows images from the same origin and data: URIs
-    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: https://public.era.nih.gov;"    # A fall back for legacy browsers that don't yet support CSP frame-ancestors.
-    Header always set X-Frame-Options "DENY"
+    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: https://public.era.nih.gov;"
 
     # Attempt to prevent some MIME-type confusion attacks. There is no perfect solution to this problem.
     Header always set X-Content-Type-Options "nosniff"
@@ -72,9 +71,9 @@ ServerTokens Prod
     # Enables built-in XSS protection in modern web browsers.
     # If a XSS is detected mode=block will block the entire page.
 
-	# A fall back for legacy browsers that don't yet support CSP frame-ancestors.
-	Header always set X-Frame-Options "DENY"
-	
+    # A fall back for legacy browsers that don't yet support CSP frame-ancestors.
+    Header always set X-Frame-Options "DENY"
+
     RewriteEngine On
     ProxyPreserveHost On
 

--- a/app-infrastructure/configs/httpd-vhosts.conf
+++ b/app-infrastructure/configs/httpd-vhosts.conf
@@ -63,9 +63,7 @@ ServerTokens Prod
     # unsafe-inline - Allows inline JavaScript, CSS, and event handlers
     # style-src - Allows inline styles but only from the same origin
     # img-src - Allows images from the same origin and data: URIs
-    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: https://public.era.nih.gov;"
-
-    # A fall back for legacy browsers that don't yet support CSP frame-ancestors.
+    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: https://public.era.nih.gov;"    # A fall back for legacy browsers that don't yet support CSP frame-ancestors.
     Header always set X-Frame-Options "DENY"
 
     # Attempt to prevent some MIME-type confusion attacks. There is no perfect solution to this problem.
@@ -73,11 +71,18 @@ ServerTokens Prod
 
     # Enables built-in XSS protection in modern web browsers.
     # If a XSS is detected mode=block will block the entire page.
-    Header always set X-XSS-Protection "1; mode=block;"
 
+	# A fall back for legacy browsers that don't yet support CSP frame-ancestors.
+	Header always set X-Frame-Options "DENY"
+	
     RewriteEngine On
     ProxyPreserveHost On
-    
+
+    # Validate the Host header
+    RewriteCond %%{HTTP_HOST} !^$
+    RewriteCond %%{HTTP_HOST} !^(www\.)?(${allowed_hosts})$ [NC]
+    RewriteRule ^ - [E=HOST:%%{HTTP_HOST},E=ALLOWED_HOSTS:${allowed_hosts},F]
+
     #Dont allow httpd debug methods
     RewriteCond %%{REQUEST_METHOD} ^TRACK
     RewriteRule .* - [F]
@@ -120,9 +125,34 @@ ServerTokens Prod
     SSLCertificateChainFile "$${HTTPD_PREFIX}/cert/preprod_server.chain"
 
     Header always set Strict-Transport-Security "max-age=31536000; includeSubdomains; preload"
+    
+    # Content security policy:
+    # frame-ancestors 'none' - Stops our application from being loaded in an iframe
+    # default-src - Restricts loading resources to the same origin
+    # script-src - Allows inline scripts but only from the same origin and unsafe-eval and unsafe-inline
+    # unsafe-eval - Allows eval() and similar constructs
+    # unsafe-inline - Allows inline JavaScript, CSS, and event handlers
+    # style-src - Allows inline styles but only from the same origin
+    # img-src - Allows images from the same origin and data: URIs
+    Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; style-src 'self' 'unsafe-inline'; worker-src 'self' blob:; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: https://public.era.nih.gov;"
+
+    # A fall back for legacy browsers that don't yet support CSP frame-ancestors.
+    Header always set X-Frame-Options "DENY"
+
+    # Attempt to prevent some MIME-type confusion attacks. There is no perfect solution to this problem.
+    Header always set X-Content-Type-Options "nosniff"
+
+    # Enables built-in XSS protection in modern web browsers.
+    # If a XSS is detected mode=block will block the entire page.
+    Header always set X-XSS-Protection "1; mode=block;"
 
     RewriteEngine On
     ProxyPreserveHost On
+
+    # Validate the Host header
+    RewriteCond %%{HTTP_HOST} !^$
+    RewriteCond %%{HTTP_HOST} !^(www\.)?(${allowed_hosts})$ [NC]
+    RewriteRule ^ - [E=HOST:%%{HTTP_HOST},E=ALLOWED_HOSTS:${allowed_hosts},F]
     
     #Dont allow httpd debug methods
     RewriteCond %%{REQUEST_METHOD} ^TRACK

--- a/app-infrastructure/httpd-instance.tf
+++ b/app-infrastructure/httpd-instance.tf
@@ -68,6 +68,7 @@ data "template_file" "httpd-vhosts-conf" {
     wildfly-base-url = "http://${aws_instance.wildfly-ec2.private_ip}:8080"
     target-stack = var.target-stack
     release-id = var.stack_githash_long
+    allowed_hosts = var.allowed_hosts
   }
 }
 

--- a/app-infrastructure/variables.tf
+++ b/app-infrastructure/variables.tf
@@ -48,3 +48,9 @@ variable "rds_master_password" {
   type        = string
   default     = "picsure!98765"  
 } 
+
+variable "allowed_hosts" {
+  description = "List of allowed hosts for hosts header validation"
+  type        = string
+  default     = ""
+}


### PR DESCRIPTION
* Update vhost and terraform

We will now allow users to set a list of domains that are acceptable in
the vhost file of httpd.

* Update variable definition

* Using double %% to escape host header

* Remove duplicate code

* Escaping more %

* Update to use terraform var

* Fix another non-escaped string

* Update vhost

Remove logging and add rewrite rule to second 443 virtual host

* Update vhost