### PR TITLE
Add blob to CSP

### DIFF
--- a/app-infrastructure/configs/httpd-vhosts.conf
+++ b/app-infrastructure/configs/httpd-vhosts.conf
@@ -64,7 +64,7 @@ ServerTokens Prod
 	# unsafe-inline - Allows inline JavaScript, CSS, and event handlers
 	# style-src - Allows inline styles but only from the same origin
 	# img-src - Allows images from the same origin and data: URIs
-	Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: https://public.era.nih.gov;"
+	Header always set Content-Security-Policy "frame-ancestors 'none'; default-src 'self'; worker-src 'self' blob:; style-src 'self' 'unsafe-inline'; script-src 'self' 'unsafe-eval' 'unsafe-inline'; img-src 'self' data: https://public.era.nih.gov blob:;"
 	
 	# A fall back for legacy browsers that don't yet support CSP frame-ancestors.
 	Header always set X-Frame-Options "DENY"


### PR DESCRIPTION
We require the addition of "blob" to the image content security policy, allowing us to download the statistical visualization image of graphs.