### PR TITLE
[ALS-4998] Update HPDS Auth & Open deployment approach

### DIFF
--- a/app-infrastructure/auth-hpds-instance.tf
+++ b/app-infrastructure/auth-hpds-instance.tf
@@ -22,7 +22,7 @@ data "template_cloudinit_config" "auth_hpds-user-data" {
 }
 
 resource "aws_instance" "auth-hpds-ec2" {
-  count = var.env_is_auth ? 0 : 1
+  count = var.include_auth_hpds ? 1 : 0
 
   ami           = local.ami_id
   instance_type = "m5.12xlarge"

--- a/app-infrastructure/open-hpds-instance.tf
+++ b/app-infrastructure/open-hpds-instance.tf
@@ -21,7 +21,7 @@ data "template_cloudinit_config" "open_hpds-user-data" {
 }
 
 resource "aws_instance" "open-hpds-ec2" {
-  count = var.env_is_open_access ? 1 : 0
+  count = var.include_open_hpds ? 1 : 0
 
   ami           = local.ami_id
   instance_type = "m5.2xlarge"

--- a/app-infrastructure/outputs.tf
+++ b/app-infrastructure/outputs.tf
@@ -10,6 +10,10 @@ output "dictionary-ec2-id" {
   value = aws_instance.dictionary-ec2.id
 }
 
-output "hpds-ec2-id" {
-  value = var.env_is_open_access ? aws_instance.open-hpds-ec2[0].id : aws_instance.auth-hpds-ec2[0].id
+output "hpds-ec2-open-id" {
+  value = var.include_open_hpds ? aws_instance.open-hpds-ec2[0].id : ""
+}
+
+output "hpds-ec2-auth-id" {
+  value = var.include_auth_hpds ? aws_instance.open-hpds-ec2[0].id : ""
 }

--- a/app-infrastructure/outputs.tf
+++ b/app-infrastructure/outputs.tf
@@ -11,9 +11,9 @@ output "dictionary-ec2-id" {
 }
 
 output "hpds-ec2-open-id" {
-  value = var.include_open_hpds ? aws_instance.auth-hpds-ec2[0].id : ""
+  value = var.include_open_hpds ? aws_instance.open-hpds-ec2[0].id : ""
 }
 
 output "hpds-ec2-auth-id" {
-  value = var.include_auth_hpds ? aws_instance.open-hpds-ec2[0].id : ""
+  value = var.include_auth_hpds ? aws_instance.auth-hpds-ec2[0].id : ""
 }

--- a/app-infrastructure/outputs.tf
+++ b/app-infrastructure/outputs.tf
@@ -11,7 +11,7 @@ output "dictionary-ec2-id" {
 }
 
 output "hpds-ec2-open-id" {
-  value = var.include_open_hpds ? aws_instance.open-hpds-ec2[0].id : ""
+  value = var.include_open_hpds ? aws_instance.auth-hpds-ec2[0].id : ""
 }
 
 output "hpds-ec2-auth-id" {

--- a/app-infrastructure/route53-template.tf
+++ b/app-infrastructure/route53-template.tf
@@ -36,7 +36,7 @@ resource "aws_route53_record" "wildfly-addr-record" {
 }
 
 resource "aws_route53_record" "open-hpds-addr-record" {
-  count   = var.env_is_open_access ? 1 : 0
+  count   = var.include_open_hpds ? 1 : 0
   zone_id = var.env_hosted_zone_id
   name    = "open-hpds.${var.target_stack}.${var.env_private_dns_name}"
   type    = "A"
@@ -45,7 +45,7 @@ resource "aws_route53_record" "open-hpds-addr-record" {
 }
 
 resource "aws_route53_record" "auth-hpds-addr-record" {
-  count   = var.env_is_open_access ? 0 : 1
+  count   = var.include_auth_hpds ? 1 : 0
   zone_id = var.env_hosted_zone_id
   name    = "auth-hpds.${var.target_stack}.${var.env_private_dns_name}"
   type    = "A"

--- a/app-infrastructure/variables.tf
+++ b/app-infrastructure/variables.tf
@@ -69,6 +69,14 @@ variable "env_is_open_access" {
   type    = bool
 }
 
+variable "include_auth_hpds" {
+    type    = bool
+}
+
+variable "include_open_hpds" {
+    type    = bool
+}
+
 # removing for now as they are secrets handled by the stack_variables
 #variable "picsure_token_introspection_token" {
 #  type    = string


### PR DESCRIPTION
HPDS auth and open are now deployed based on different variables. This allows a user to select auth, open, or both. env_is_open_access will only be used to set the tag.