### PR TITLE
Adding target group attachment

### DIFF
--- a/app-infrastructure/auth-hpds-instance.tf
+++ b/app-infrastructure/auth-hpds-instance.tf
@@ -48,7 +48,8 @@ resource "aws_instance" "auth-hpds-ec2" {
   tags = {
     Owner       = "Avillach_Lab"
     Environment = var.environment_name
-    Stack       = var.env_staging_subdomain
+    Stack       = var.target_stack
+    isLive      = local.is_live
     Project     = local.project
     Name        = "Auth HPDS - ${var.target_stack} - ${var.stack_githash}"
   }

--- a/app-infrastructure/dictionary-instance.tf
+++ b/app-infrastructure/dictionary-instance.tf
@@ -45,8 +45,9 @@ resource "aws_instance" "dictionary-ec2" {
   tags = {
     Owner       = "Avillach_Lab"
     Environment = var.environment_name
-    Stack       = var.env_staging_subdomain
+    Stack       = var.target_stack
     Project     = local.project
+    isLive      = local.is_live
     Name        = "Dictionary - ${var.target_stack} - ${var.stack_githash}"
   }
 

--- a/app-infrastructure/httpd-instance.tf
+++ b/app-infrastructure/httpd-instance.tf
@@ -45,7 +45,8 @@ resource "aws_instance" "httpd-ec2" {
   tags = {
     Owner       = "Avillach_Lab"
     Environment = var.environment_name
-    Stack       = var.env_staging_subdomain
+    Stack       = var.target_stack
+    isLive      = local.is_live
     Project     = local.project
     Name        = "Apache HTTPD - ${var.target_stack} - ${var.stack_githash}"
   }

--- a/app-infrastructure/open-hpds-instance.tf
+++ b/app-infrastructure/open-hpds-instance.tf
@@ -48,8 +48,9 @@ resource "aws_instance" "open-hpds-ec2" {
     Owner       = "Avillach_Lab"
     Environment = var.environment_name
     Project     = local.project
-    Stack       = var.env_staging_subdomain
+    Stack       = var.target_stack
     Name        = "Open HPDS - ${var.target_stack} - ${var.stack_githash}"
+    isLive      = local.is_live
   }
 
   metadata_options {

--- a/app-infrastructure/provider.tf
+++ b/app-infrastructure/provider.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = "us-east-1"
   profile = "avillachlab-secure-infrastructure"
-  version = "5.17"
+  version = "3.74"
 
 }

--- a/app-infrastructure/provider.tf
+++ b/app-infrastructure/provider.tf
@@ -1,6 +1,6 @@
 provider "aws" {
   region  = "us-east-1"
   profile = "avillachlab-secure-infrastructure"
-  version = "3.74"
+  version = "5.17"
 
 }

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -16,7 +16,7 @@ data "aws_lb_target_group" "lb_tg_data" {
 # use the arn from data resource staging.
 # use the instance-id for the httpd server < instance-id does not seem to work with current provider. Can use private ip.
 # each stack gets attached to a single tg
-
+# availability zone must be all to use vpcs out of scope of the alb.
 resource "aws_lb_target_group_attachment" "stack_lb_tga" {
   target_group_arn  = data.aws_lb_target_group.lb_tg_data.arn
   target_id         = aws_instance.httpd-ec2.private_ip

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -7,28 +7,28 @@ data "aws_lb_target_group" "staging" {
   }
   filter = {
     name = "tag:Stack"
-    values = [ var.env_staging_subdomain ]
+    values = [ var.lb_target_stack ]
   }
-  # change this to find the target group dynamically
 }
 
 # use the arn from data resource staging.
 # use the instance-id for the httpd server
-resource "aws_lb_target_group_attachment" "test" {
-  target_group_arn = aws_instance.staging.arn
+# each stack gets attached to a single tg
+resource "aws_lb_target_group_attachment" "stack_lb_tga" {
+  target_group_arn = data.aws_lb_target_group.staging.arn
   target_id        = aws_instance.httpd-ec2.id
   port             = 443
   availability_zone = "all"
 }
 
-variable "lb_tg_arn" {
-  type    = string
+# used to promote the tga to the live target group.
+# by default deployment should be always deploying to the staging environment.
+# using this 
+variable "is_promote_lb_tg" {
+  type	=	bool
+  default = false
 }
 
-variable "lb_tg_name" {
-  type    = string
-}
-
-variable "target_id" {
-  type    = string
+local {
+  lb_target_stack = is_promote_lb_tg ? var.env_live_subdomain : var.env_staging_subdomain
 }

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -30,7 +30,7 @@ variable "is_promote_lb_tg" {
 }
 # variable to handle if we are promoting  
 # is_live tag to let us know if the stack is the live server or not.
-local {
+locals {
   lb_target_stack = is_promote_lb_tg ? var.env_live_subdomain : var.env_staging_subdomain
   is_live = is_promote_lb_tg ? true: false
 }

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -14,7 +14,7 @@ data "aws_lb_target_group" "lb_tg_data" {
 }
 
 # use the arn from data resource staging.
-# use the instance-id for the httpd server
+# use the instance-id for the httpd server < instance-id does not seem to work with current provider. Can use private ip.
 # each stack gets attached to a single tg
 
 resource "aws_lb_target_group_attachment" "stack_lb_tga" {

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -33,10 +33,10 @@ variable "is_promote_lb_tg" {
 }
 
 #### Remove these when moving to tags.  
-variable "staging_lb_name: {
+variable "staging_lb_name" {
   type = string
 }
-variable "live_lb_name: {
+variable "live_lb_name" {
   type = string
 }
 

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -5,10 +5,10 @@ data "aws_lb_target_group" "lb_tg_data" {
     name = "tag:Project"
     values = [ local.project ]
   }
-  filter = {
-    name = "tag:Stack"
-    values = [ var.lb_target_stack ]
-  }
+  #filter = {
+  #  name = "tag:Stack"
+  #  values = [ var.lb_target_stack ]
+  #}
 }
 
 # use the arn from data resource staging.

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -50,6 +50,6 @@ locals {
   is_live         = var.is_promote_lb_tg ? true: false
   
   # for use to support not having tags remove when provider is updated
-  alb_name        = var.is_promote_lb_tg ? var.live_lb_name: staging_lb_name
+  alb_name        = var.is_promote_lb_tg ? var.live_lb_name: var.staging_lb_name
   
 }

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -2,10 +2,15 @@
 # Use tags for Project and Stack to find correct target group to update
 
 data "aws_lb_target_group" "lb_tg_data" {
-  tags = {
-    Project = local.project
-    Stack	= local.lb_target_stack
-  }
+  # need to use name or arn with current provider
+  name = local.alb_name
+  # cannot use tags with current aws provider.
+  # updating the provider broke other things
+  # implement tags once provider can be updated to latest.
+  #tags = {
+  #  Project = local.project
+  #  Stack	= local.lb_target_stack
+  #}
 }
 
 # use the arn from data resource staging.
@@ -13,25 +18,38 @@ data "aws_lb_target_group" "lb_tg_data" {
 # each stack gets attached to a single tg
 
 resource "aws_lb_target_group_attachment" "stack_lb_tga" {
-  target_group_arn = data.aws_lb_target_group.lb_tg_data.arn
-  target_id        = aws_instance.httpd-ec2.id
-  port             = 443
+  target_group_arn  = data.aws_lb_target_group.lb_tg_data.arn
+  target_id         = aws_instance.httpd-ec2.id
+  port              = 443
   availability_zone = "all"
 }
 
 # used to promote the tga to the live target group.
 # by default deployment should be always deploying to the staging environment.
-# using this
- 
+# this should only be set to true when promoting staging to live.
 variable "is_promote_lb_tg" {
-  type	=	bool
+  type	  =	bool
   default = false
 }
+
+#### Remove these when moving to tags.  
+variable "staging_lb_name: {
+  type = string
+}
+variable "live_lb_name: {
+  type = string
+}
+
+#####
 
 # variable to handle if we are promoting  
 # is_live tag to let us know if the stack is the live server or not.
 
 locals {
   lb_target_stack = var.is_promote_lb_tg ? var.env_live_subdomain : var.env_staging_subdomain
-  is_live = var.is_promote_lb_tg ? true: false
+  is_live         = var.is_promote_lb_tg ? true: false
+  
+  # for use to support not having tags remove when provider is updated
+  alb_name        = var.is_promote_lb_tg ? var.live_lb_name: staging_lb_name
+  
 }

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -32,6 +32,6 @@ variable "is_promote_lb_tg" {
 # is_live tag to let us know if the stack is the live server or not.
 
 locals {
-  lb_target_stack = is_promote_lb_tg ? var.env_live_subdomain : var.env_staging_subdomain
-  is_live = is_promote_lb_tg ? true: false
+  lb_target_stack = var.is_promote_lb_tg ? var.env_live_subdomain : var.env_staging_subdomain
+  is_live = var.is_promote_lb_tg ? true: false
 }

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -1,0 +1,34 @@
+# Doing a lookup for the staging environments target group and attach the http instance that is being deployed
+# Use tags for Project and Stack to find correct target group to update
+data "aws_lb_target_group" "staging" {
+  filter = {
+    name = "tag:Project"
+    values = [ local.project ]
+  }
+  filter = {
+    name = "tag:Stack"
+    values = [ var.env_staging_subdomain ]
+  }
+  # change this to find the target group dynamically
+}
+
+# use the arn from data resource staging.
+# use the instance-id for the httpd server
+resource "aws_lb_target_group_attachment" "test" {
+  target_group_arn = aws_instance.staging.arn
+  target_id        = aws_instance.httpd-ec2.id
+  port             = 443
+  availability_zone = "all"
+}
+
+variable "lb_tg_arn" {
+  type    = string
+}
+
+variable "lb_tg_name" {
+  type    = string
+}
+
+variable "target_id" {
+  type    = string
+}

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -1,14 +1,10 @@
 # Doing a lookup for the staging environments target group and attach the http instance that is being deployed
 # Use tags for Project and Stack to find correct target group to update
 data "aws_lb_target_group" "lb_tg_data" {
-  filter = {
-    name = "tag:Project"
-    values = [ local.project ]
+  tags = {
+    Project = local.project
+    Stack	= var.lb_target_stack
   }
-  #filter = {
-  #  name = "tag:Stack"
-  #  values = [ var.lb_target_stack ]
-  #}
 }
 
 # use the arn from data resource staging.

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -1,6 +1,6 @@
 # Doing a lookup for the staging environments target group and attach the http instance that is being deployed
 # Use tags for Project and Stack to find correct target group to update
-data "aws_lb_target_group" "staging" {
+data "aws_lb_target_group" "lb_tg_data" {
   filter = {
     name = "tag:Project"
     values = [ local.project ]
@@ -15,7 +15,7 @@ data "aws_lb_target_group" "staging" {
 # use the instance-id for the httpd server
 # each stack gets attached to a single tg
 resource "aws_lb_target_group_attachment" "stack_lb_tga" {
-  target_group_arn = data.aws_lb_target_group.staging.arn
+  target_group_arn = data.aws_lb_target_group.lb_tg_data.arn
   target_id        = aws_instance.httpd-ec2.id
   port             = 443
   availability_zone = "all"
@@ -28,7 +28,9 @@ variable "is_promote_lb_tg" {
   type	=	bool
   default = false
 }
-
+# variable to handle if we are promoting  
+# is_live tag to let us know if the stack is the live server or not.
 local {
   lb_target_stack = is_promote_lb_tg ? var.env_live_subdomain : var.env_staging_subdomain
+  is_live = is_promote_lb_tg ? true: false
 }

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -19,7 +19,7 @@ data "aws_lb_target_group" "lb_tg_data" {
 
 resource "aws_lb_target_group_attachment" "stack_lb_tga" {
   target_group_arn  = data.aws_lb_target_group.lb_tg_data.arn
-  target_id         = aws_instance.httpd-ec2.id
+  target_id         = aws_instance.httpd-ec2.private_ip
   port              = 443
   availability_zone = "all"
 }

--- a/app-infrastructure/target-group-attachment.tf
+++ b/app-infrastructure/target-group-attachment.tf
@@ -1,15 +1,17 @@
 # Doing a lookup for the staging environments target group and attach the http instance that is being deployed
 # Use tags for Project and Stack to find correct target group to update
+
 data "aws_lb_target_group" "lb_tg_data" {
   tags = {
     Project = local.project
-    Stack	= var.lb_target_stack
+    Stack	= local.lb_target_stack
   }
 }
 
 # use the arn from data resource staging.
 # use the instance-id for the httpd server
 # each stack gets attached to a single tg
+
 resource "aws_lb_target_group_attachment" "stack_lb_tga" {
   target_group_arn = data.aws_lb_target_group.lb_tg_data.arn
   target_id        = aws_instance.httpd-ec2.id
@@ -19,13 +21,16 @@ resource "aws_lb_target_group_attachment" "stack_lb_tga" {
 
 # used to promote the tga to the live target group.
 # by default deployment should be always deploying to the staging environment.
-# using this 
+# using this
+ 
 variable "is_promote_lb_tg" {
   type	=	bool
   default = false
 }
+
 # variable to handle if we are promoting  
 # is_live tag to let us know if the stack is the live server or not.
+
 locals {
   lb_target_stack = is_promote_lb_tg ? var.env_live_subdomain : var.env_staging_subdomain
   is_live = is_promote_lb_tg ? true: false

--- a/app-infrastructure/variables.tf
+++ b/app-infrastructure/variables.tf
@@ -42,6 +42,11 @@ variable "env_staging_subdomain" {
   type        = string
 }
 
+variable "env_live_subdomain" {
+  description = "Add Stack Tag"
+  type        = string
+}
+
 variable "rds_master_username" {
   description = "Master Username"
   type        = string

--- a/app-infrastructure/wildfly-instance.tf
+++ b/app-infrastructure/wildfly-instance.tf
@@ -50,7 +50,7 @@ resource "aws_instance" "wildfly-ec2" {
     Owner       = "Avillach_Lab"
     Environment = var.environment_name
     Project     = local.project
-    Stack       = var.env_staging_subdomain
+    Stack       = var.target_stack
     Name        = "Wildfly - ${var.target_stack} - ${var.stack_githash}"
   }
 


### PR DESCRIPTION
* Updating tf to handle attaching staging TG to the deployment targets private ip
* The is_promote_lb_tg local variable does the logic switching between deployment and a staging to live promotion.
* The deployment will always be deployed to the predev TG so the flag is not set in teardown process it will use the default value always.  
* The job that will replace move dns pointer will simply set is_promote_lb_tg to true and apply.  Terraform will then register current staging stack's state to the the live alb ( dev ).  It will then demote the current live stack's state to predev.
* Cannot use tags to find the albs with current aws provider version.  Attempted to just update the provider but that cause other issues that were out of scope.
* In order to work around that we can simply pass the albs we want to assign to staging and live using the env_live_subdomain and env_staging_subdomain.  env_staging_subdomain already existed.
* The code to use tags is still there and can be applied once provider is updated.