### PR TITLE
Feature/fixes for auth deployment

### DIFF
--- a/app-infrastructure/auth-hpds-instance.tf
+++ b/app-infrastructure/auth-hpds-instance.tf
@@ -30,7 +30,7 @@ resource "aws_instance" "auth-hpds-ec2" {
 
   subnet_id = local.private2_subnet_ids[0]
 
-  iam_instance_profile = "auth-hpds-deployment-s3-profile-${var.target_stack}-${var.stack_githash}"
+  iam_instance_profile = "auth-hpds-deployment-s3-profile-${var.target_stack}-${local.uniq_name}"
 
   user_data = data.template_cloudinit_config.auth_hpds-user-data.rendered
 
@@ -50,7 +50,7 @@ resource "aws_instance" "auth-hpds-ec2" {
     Environment = var.environment_name
     Stack       = var.target_stack
     Project     = local.project
-    Name        = "Auth HPDS - ${var.target_stack} - ${var.stack_githash}"
+    Name        = "Auth HPDS - ${var.target_stack} - ${local.uniq_name}"
   }
 
   metadata_options {

--- a/app-infrastructure/auth-hpds-instance.tf
+++ b/app-infrastructure/auth-hpds-instance.tf
@@ -23,7 +23,7 @@ data "template_cloudinit_config" "auth_hpds-user-data" {
 }
 
 resource "aws_instance" "auth-hpds-ec2" {
-  count = var.include_auth_hpds ? 0 : 1
+  count = var.include_auth_hpds ? 1 : 0
 
   ami           = local.ami_id
   instance_type = "m5.12xlarge"

--- a/app-infrastructure/auth-hpds-instance.tf
+++ b/app-infrastructure/auth-hpds-instance.tf
@@ -23,7 +23,7 @@ data "template_cloudinit_config" "auth_hpds-user-data" {
 }
 
 resource "aws_instance" "auth-hpds-ec2" {
-  count = var.include_auth_hpds ? 1 : 0
+  count = var.include_auth_hpds ? 0 : 1
 
   ami           = local.ami_id
   instance_type = "m5.12xlarge"

--- a/app-infrastructure/configs/aggregate-resource.properties
+++ b/app-infrastructure/configs/aggregate-resource.properties
@@ -2,3 +2,4 @@ target.picsure.url=http://open-hpds.${target_stack}.${env_private_dns_name}:8080
 target.picsure.token=
 target.picsure.obfuscation_threshold=10
 target.picsure.obfuscation_variance=3
+visualization.resource.id=ca0ad4a9-130a-3a8a-ae00-e35b07f1108b

--- a/app-infrastructure/configs/picsureui_settings.json
+++ b/app-infrastructure/configs/picsureui_settings.json
@@ -99,5 +99,5 @@
   "idp_provider":"${idp_provider}",
   "idp_provider_uri":"${idp_provider_uri}",
   "fence_client_id":"${fence_client_id}",
-  "analytics_id":"${analytics_id}"
+  "analyticsId":"${analytics_id}"
 }

--- a/app-infrastructure/dictionary-instance.tf
+++ b/app-infrastructure/dictionary-instance.tf
@@ -27,7 +27,7 @@ resource "aws_instance" "dictionary-ec2" {
 
   subnet_id = local.private2_subnet_ids[0]
 
-  iam_instance_profile = "dictionary-deployment-s3-profile-${var.target_stack}-${var.stack_githash}"
+  iam_instance_profile = "dictionary-deployment-s3-profile-${var.target_stack}-${local.uniq_name}"
 
   user_data = data.template_cloudinit_config.dictionary-user-data.rendered
 
@@ -47,7 +47,7 @@ resource "aws_instance" "dictionary-ec2" {
     Environment = var.environment_name
     Stack       = var.target_stack
     Project     = local.project
-    Name        = "Dictionary - ${var.target_stack} - ${var.stack_githash}"
+    Name        = "Dictionary - ${var.target_stack} - ${local.uniq_name}"
   }
 
   metadata_options {

--- a/app-infrastructure/httpd-instance.tf
+++ b/app-infrastructure/httpd-instance.tf
@@ -48,7 +48,7 @@ resource "aws_instance" "httpd-ec2" {
     Environment = var.environment_name
     Stack       = var.target_stack
     Project     = local.project
-    Name        = "Apache HTTPD - ${var.target_stack} - ${var.stack_githash}"
+    Name        = "Apache HTTPD - ${var.target_stack} - ${local.uniq_name}"
   }
 
   metadata_options {

--- a/app-infrastructure/httpd-instance.tf
+++ b/app-infrastructure/httpd-instance.tf
@@ -27,7 +27,7 @@ resource "aws_instance" "httpd-ec2" {
 
   subnet_id = local.private1_subnet_ids[0]
 
-  iam_instance_profile = "httpd-deployment-s3-profile-${var.target_stack}-${var.stack_githash}"
+  iam_instance_profile = "httpd-deployment-s3-profile-${var.target_stack}-${local.uniq_name}"
 
   user_data = data.template_cloudinit_config.httpd-user-data.rendered
 

--- a/app-infrastructure/locals.tf
+++ b/app-infrastructure/locals.tf
@@ -1,8 +1,19 @@
+
 #Lookup latest AMI
 data "aws_ami" "centos" {
   most_recent = true
   owners      = ["752463128620"]
   name_regex  = "^srce-centos7-golden-*"
+}
+
+# Random string to use for dynamic names.
+# use to get rid of git_hash in names causes conflicts if different env use same release controls
+resource "random_string" "random" {
+   length  = 6
+   special = false
+}
+locals {
+   uniq_name = random_string.random.result
 }
 
 data "aws_vpc" "target_vpc" {

--- a/app-infrastructure/open-hpds-instance.tf
+++ b/app-infrastructure/open-hpds-instance.tf
@@ -49,7 +49,7 @@ resource "aws_instance" "open-hpds-ec2" {
     Environment = var.environment_name
     Project     = local.project
     Stack       = var.target_stack
-    Name        = "Open HPDS - ${var.target_stack} - ${var.stack_githash}"
+    Name        = "Open HPDS - ${var.target_stack} - ${local.uniq_name}"
   }
 
   metadata_options {

--- a/app-infrastructure/open-hpds-instance.tf
+++ b/app-infrastructure/open-hpds-instance.tf
@@ -29,7 +29,7 @@ resource "aws_instance" "open-hpds-ec2" {
 
   subnet_id = local.private2_subnet_ids[0]
 
-  iam_instance_profile = "open-hpds-deployment-s3-profile-${var.target_stack}-${var.stack_githash}"
+  iam_instance_profile = "open-hpds-deployment-s3-profile-${var.target_stack}-${local.uniq_name}"
 
   user_data = data.template_cloudinit_config.open_hpds-user-data.rendered
 

--- a/app-infrastructure/outputs.tf
+++ b/app-infrastructure/outputs.tf
@@ -11,11 +11,11 @@ output "dictionary-ec2-id" {
 }
 
 output "hpds-ec2-open-id" {
-  value = var.include_open_hpds ? local.open_hpds_instance_id
+  value = local.open_hpds_instance_id
 }
 
 output "hpds-ec2-auth-id" {
-  value = var.include_auth_hpds ? local.auth_instance_id
+  value = local.auth_instance_id
 }
 
 locals {

--- a/app-infrastructure/outputs.tf
+++ b/app-infrastructure/outputs.tf
@@ -19,6 +19,6 @@ output "hpds-ec2-auth-id" {
 }
 
 locals {
-  open_hpds_instance_id = length(aws_instance.open-hpds-ec2) > 1 ? aws_instance.open-hpds-ec2[0].id : "No Open HPDS Instances Available"
-  auth_hpds_instance_id = length(aws_instance.auth-hpds-ec2) > 1 ? aws_instance.auth-hpds-ec2[0].id : "No Auth HPDS Instances Available"
+  open_hpds_instance_id = length(aws_instance.open-hpds-ec2) > 0 ? aws_instance.open-hpds-ec2[0].id : "No Open HPDS Instances Available"
+  auth_hpds_instance_id = length(aws_instance.auth-hpds-ec2) > 0 ? aws_instance.auth-hpds-ec2[0].id : "No Auth HPDS Instances Available"
 }

--- a/app-infrastructure/outputs.tf
+++ b/app-infrastructure/outputs.tf
@@ -19,6 +19,6 @@ output "hpds-ec2-auth-id" {
 }
 
 locals {
-  open_hpds_instance_id = length(aws_instance.open-hpds-ec2) > 0 ? aws_instance.open-hpds-ec2[0].id : "No Open HPDS Instances Available"
-  auth_hpds_instance_id = length(aws_instance.auth-hpds-ec2) > 0 ? aws_instance.auth-hpds-ec2[0].id : "No Auth HPDS Instances Available"
+  open_hpds_instance_id = length(aws_instance.open-hpds-ec2) > 0 ? aws_instance.open-hpds-ec2[0].id : ""
+  auth_hpds_instance_id = length(aws_instance.auth-hpds-ec2) > 0 ? aws_instance.auth-hpds-ec2[0].id : ""
 }

--- a/app-infrastructure/outputs.tf
+++ b/app-infrastructure/outputs.tf
@@ -14,6 +14,6 @@ output "hpds-ec2-open-id" {
   value = var.include_open_hpds ? aws_instance.open-hpds-ec2[0].id : ""
 }
 
-output "hpds-ec2-auth-id" {
-  value = var.include_auth_hpds ? aws_instance.auth-hpds-ec2[0].id : ""
-}
+#output "hpds-ec2-auth-id" {
+#  value = var.include_auth_hpds ? aws_instance.auth-hpds-ec2[0].id : ""
+#}

--- a/app-infrastructure/outputs.tf
+++ b/app-infrastructure/outputs.tf
@@ -11,9 +11,14 @@ output "dictionary-ec2-id" {
 }
 
 output "hpds-ec2-open-id" {
-  value = var.include_open_hpds ? aws_instance.open-hpds-ec2[0].id : ""
+  value = var.include_open_hpds ? local.open_hpds_instance_id
 }
 
 output "hpds-ec2-auth-id" {
-  value = var.include_auth_hpds ? aws_instance.auth-hpds-ec2[0].id : ""
+  value = var.include_auth_hpds ? local.auth_instance_id
+}
+
+locals {
+  open_hpds_instance_id = length(aws_instance.open-hpds-ec2) > 1 ? aws_instance.open-hpds-ec2[0].id : "No Open HPDS Instances Available"
+  auth_hpds_instance_id = length(aws_instance.auth-hpds-ec2) > 1 ? aws_instance.auth-hpds-ec2[0].id : "No Auth HPDS Instances Available"
 }

--- a/app-infrastructure/outputs.tf
+++ b/app-infrastructure/outputs.tf
@@ -15,7 +15,7 @@ output "hpds-ec2-open-id" {
 }
 
 output "hpds-ec2-auth-id" {
-  value = local.auth_instance_id
+  value = local.auth_hpds_instance_id
 }
 
 locals {

--- a/app-infrastructure/outputs.tf
+++ b/app-infrastructure/outputs.tf
@@ -14,6 +14,6 @@ output "hpds-ec2-open-id" {
   value = var.include_open_hpds ? aws_instance.open-hpds-ec2[0].id : ""
 }
 
-#output "hpds-ec2-auth-id" {
-#  value = var.include_auth_hpds ? aws_instance.auth-hpds-ec2[0].id : ""
-#}
+output "hpds-ec2-auth-id" {
+  value = var.include_auth_hpds ? aws_instance.auth-hpds-ec2[0].id : ""
+}

--- a/app-infrastructure/picsure-db.tf
+++ b/app-infrastructure/picsure-db.tf
@@ -18,7 +18,7 @@ resource "aws_db_instance" "pic-sure-mysql" {
     Environment = var.environment_name
     Stack       = var.target_stack
     Project     = var.env_project
-    Name        = "PIC-SURE DB Instance - ${var.target_stack} - ${var.stack_githash}"
+    Name        = "PIC-SURE DB Instance - ${var.target_stack} - ${local.uniq_name}"
   }
 }
 

--- a/app-infrastructure/s3_roles.tf
+++ b/app-infrastructure/s3_roles.tf
@@ -82,7 +82,7 @@ EOF
 }
 
 resource "aws_iam_role" "wildfly-deployment-s3-role" {
-  name               = "wildfly-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
+  name               = "${env_project}-wildfly-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -211,7 +211,7 @@ EOF
 }
 
 resource "aws_iam_role" "httpd-deployment-s3-role" {
-  name               = "httpd-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
+  name               = "${env_project}-httpd-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -303,7 +303,7 @@ EOF
 }
 
 resource "aws_iam_role" "auth-hpds-deployment-s3-role" {
-  name               = "auth-hpds-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
+  name               = "${env_project}-auth-hpds-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -389,7 +389,7 @@ EOF
 }
 
 resource "aws_iam_role" "open-hpds-deployment-s3-role" {
-  name               = "open-hpds-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
+  name               = "${env_project}-open-hpds-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -461,7 +461,7 @@ EOF
 }
 
 resource "aws_iam_role" "dictionary-deployment-s3-role" {
-  name               = "dictionary-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
+  name               = "${env_project}-dictionary-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/app-infrastructure/s3_roles.tf
+++ b/app-infrastructure/s3_roles.tf
@@ -1,11 +1,11 @@
 
 resource "aws_iam_instance_profile" "wildfly-deployment-s3-profile" {
-  name = "wildfly-deployment-s3-profile-${var.target_stack}-${var.stack_githash}"
+  name = "wildfly-deployment-s3-profile-${var.target_stack}-${local.uniq_name}"
   role = aws_iam_role.wildfly-deployment-s3-role.name
 }
 
 resource "aws_iam_role_policy" "wildfly-deployment-s3-policy" {
-  name   = "wildfly-deployment-s3-policy-${var.target_stack}-${var.stack_githash}"
+  name   = "wildfly-deployment-s3-policy-${var.target_stack}-${local.uniq_name}"
   role   = aws_iam_role.wildfly-deployment-s3-role.id
   policy = <<EOF
 {
@@ -82,7 +82,7 @@ EOF
 }
 
 resource "aws_iam_role" "wildfly-deployment-s3-role" {
-  name               = "wildfly-deployment-s3-role-${var.target_stack}-${var.stack_githash}"
+  name               = "wildfly-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -111,12 +111,12 @@ resource "aws_iam_role_policy_attachment" "attach-cloudwatch-ssm-policy-to-wildf
 
 
 resource "aws_iam_instance_profile" "httpd-deployment-s3-profile" {
-  name = "httpd-deployment-s3-profile-${var.target_stack}-${var.stack_githash}"
+  name = "httpd-deployment-s3-profile-${var.target_stack}-${local.uniq_name}"
   role = aws_iam_role.httpd-deployment-s3-role.name
 }
 
 resource "aws_iam_role_policy" "httpd-deployment-s3-policy" {
-  name   = "httpd-deployment-s3-policy-${var.target_stack}-${var.stack_githash}"
+  name   = "httpd-deployment-s3-policy-${var.target_stack}-${local.uniq_name}"
   role   = aws_iam_role.httpd-deployment-s3-role.id
   policy = <<EOF
 {
@@ -211,7 +211,7 @@ EOF
 }
 
 resource "aws_iam_role" "httpd-deployment-s3-role" {
-  name               = "httpd-deployment-s3-role-${var.target_stack}-${var.stack_githash}"
+  name               = "httpd-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -240,12 +240,12 @@ resource "aws_iam_role_policy_attachment" "attach-cloudwatch-ssm-policy-to-httpd
 
 
 resource "aws_iam_instance_profile" "auth-hpds-deployment-s3-profile" {
-  name = "auth-hpds-deployment-s3-profile-${var.target_stack}-${var.stack_githash}"
+  name = "auth-hpds-deployment-s3-profile-${var.target_stack}-${local.uniq_name}"
   role = aws_iam_role.auth-hpds-deployment-s3-role.name
 }
 
 resource "aws_iam_role_policy" "auth-hpds-deployment-s3-policy" {
-  name   = "auth-hpds-deployment-s3-policy-${var.target_stack}-${var.stack_githash}"
+  name   = "auth-hpds-deployment-s3-policy-${var.target_stack}-${local.uniq_name}"
   role   = aws_iam_role.auth-hpds-deployment-s3-role.id
   policy = <<EOF
 {
@@ -303,7 +303,7 @@ EOF
 }
 
 resource "aws_iam_role" "auth-hpds-deployment-s3-role" {
-  name               = "auth-hpds-deployment-s3-role-${var.target_stack}-${var.stack_githash}"
+  name               = "auth-hpds-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -332,12 +332,12 @@ resource "aws_iam_role_policy_attachment" "attach-cloudwatch-ssm-policy-to-auth-
 
 
 resource "aws_iam_instance_profile" "open-hpds-deployment-s3-profile" {
-  name = "open-hpds-deployment-s3-profile-${var.target_stack}-${var.stack_githash}"
+  name = "open-hpds-deployment-s3-profile-${var.target_stack}-${local.uniq_name}"
   role = aws_iam_role.open-hpds-deployment-s3-role.name
 }
 
 resource "aws_iam_role_policy" "open-hpds-deployment-s3-policy" {
-  name   = "open-hpds-deployment-s3-policy-${var.target_stack}-${var.stack_githash}"
+  name   = "open-hpds-deployment-s3-policy-${var.target_stack}-${local.uniq_name}"
   role   = aws_iam_role.open-hpds-deployment-s3-role.id
   policy = <<EOF
 {
@@ -389,7 +389,7 @@ EOF
 }
 
 resource "aws_iam_role" "open-hpds-deployment-s3-role" {
-  name               = "open-hpds-deployment-s3-role-${var.target_stack}-${var.stack_githash}"
+  name               = "open-hpds-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -418,12 +418,12 @@ resource "aws_iam_role_policy_attachment" "attach-cloudwatch-ssm-policy-to-open-
 
 
 resource "aws_iam_instance_profile" "dictionary-deployment-s3-profile" {
-  name = "dictionary-deployment-s3-profile-${var.target_stack}-${var.stack_githash}"
+  name = "dictionary-deployment-s3-profile-${var.target_stack}-${local.uniq_name}"
   role = aws_iam_role.dictionary-deployment-s3-role.name
 }
 
 resource "aws_iam_role_policy" "dictionary-deployment-s3-policy" {
-  name   = "dictionary-deployment-s3-policy-${var.target_stack}-${var.stack_githash}"
+  name   = "dictionary-deployment-s3-policy-${var.target_stack}-${local.uniq_name}"
   role   = aws_iam_role.dictionary-deployment-s3-role.id
   policy = <<EOF
 {
@@ -461,7 +461,7 @@ EOF
 }
 
 resource "aws_iam_role" "dictionary-deployment-s3-role" {
-  name               = "dictionary-deployment-s3-role-${var.target_stack}-${var.stack_githash}"
+  name               = "dictionary-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",

--- a/app-infrastructure/s3_roles.tf
+++ b/app-infrastructure/s3_roles.tf
@@ -82,7 +82,7 @@ EOF
 }
 
 resource "aws_iam_role" "wildfly-deployment-s3-role" {
-  name               = "${env_project}-wildfly-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
+  name               = "${local.project_no_space}-wildfly-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -211,7 +211,7 @@ EOF
 }
 
 resource "aws_iam_role" "httpd-deployment-s3-role" {
-  name               = "${env_project}-httpd-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
+  name               = "${local.project_no_space}-httpd-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -303,7 +303,7 @@ EOF
 }
 
 resource "aws_iam_role" "auth-hpds-deployment-s3-role" {
-  name               = "${env_project}-auth-hpds-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
+  name               = "${local.project_no_space}-auth-hpds-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -389,7 +389,7 @@ EOF
 }
 
 resource "aws_iam_role" "open-hpds-deployment-s3-role" {
-  name               = "${env_project}-open-hpds-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
+  name               = "${local.project_no_space}-open-hpds-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -461,7 +461,7 @@ EOF
 }
 
 resource "aws_iam_role" "dictionary-deployment-s3-role" {
-  name               = "${env_project}-dictionary-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
+  name               = "${local.project_no_space}-dictionary-deployment-s3-role-${var.target_stack}-${local.uniq_name}"
   assume_role_policy = <<EOF
 {
   "Version": "2012-10-17",
@@ -486,5 +486,9 @@ resource "aws_iam_role_policy_attachment" "attach-cloudwatch-server-policy-to-di
 resource "aws_iam_role_policy_attachment" "attach-cloudwatch-ssm-policy-to-dictionary-role" {
   role       = aws_iam_role.dictionary-deployment-s3-role.name
   policy_arn = "arn:aws:iam::aws:policy/AmazonSSMManagedInstanceCore"
+}
+
+locals {
+  project_no_space     = replace(var.env_project, " ", "_")
 }
 

--- a/app-infrastructure/s3_roles.tf
+++ b/app-infrastructure/s3_roles.tf
@@ -489,6 +489,6 @@ resource "aws_iam_role_policy_attachment" "attach-cloudwatch-ssm-policy-to-dicti
 }
 
 locals {
-  project_no_space     = replace(var.env_project, " ", "_")
+  project_no_space     = replace(var.env_project, " ", "-")
 }
 

--- a/app-infrastructure/security-groups.tf
+++ b/app-infrastructure/security-groups.tf
@@ -1,6 +1,6 @@
 ### Inbound
 resource "aws_security_group" "inbound-httpd-from-alb" {
-  name        = "allow_inbound_from_public_subnet_to_httpd_${var.stack_githash}"
+  name        = "allow_inbound_from_public_subnet_to_httpd_${local.uniq_name}"
   description = "Allow inbound traffic from public subnets to httpd servers"
   vpc_id      = local.target_vpc
 
@@ -14,12 +14,12 @@ resource "aws_security_group" "inbound-httpd-from-alb" {
   tags = {
     Owner       = "Avillach_Lab"
     Environment = var.environment_name
-    Name        = "inbound-from-public-internet Security Group - ${var.target_stack} - ${var.stack_githash}"
+    Name        = "inbound-from-public-internet Security Group - ${var.target_stack} - ${local.uniq_name}"
   }
 }
 
 resource "aws_security_group" "inbound-wildfly-from-httpd" {
-  name        = "allow_inbound_from_httpd_subnet_${var.stack_githash}"
+  name        = "allow_inbound_from_httpd_subnet_${local.uniq_name}"
   description = "Allow inbound traffic from httpd to port 8080 on wildfly"
   vpc_id      = local.target_vpc
 
@@ -34,13 +34,13 @@ resource "aws_security_group" "inbound-wildfly-from-httpd" {
   tags = {
     Owner       = "Avillach_Lab"
     Environment = var.environment_name
-    Name        = "inbound-for-hpds Security Group - ${var.target_stack} - ${var.stack_githash}"
+    Name        = "inbound-for-hpds Security Group - ${var.target_stack} - ${local.uniq_name}"
   }
 }
 
 
 resource "aws_security_group" "inbound-hpds-from-wildfly" {
-  name        = "allow_inbound_from_private_subnet_to_hpds_${var.stack_githash}"
+  name        = "allow_inbound_from_private_subnet_to_hpds_${local.uniq_name}"
   description = "Allow inbound traffic from private-subnets on port 8080 for hpds"
   vpc_id      = local.target_vpc
 
@@ -54,13 +54,13 @@ resource "aws_security_group" "inbound-hpds-from-wildfly" {
   tags = {
     Owner       = "Avillach_Lab"
     Environment = var.environment_name
-    Name        = "inbound-hpds Security Group - ${var.target_stack} - ${var.stack_githash}"
+    Name        = "inbound-hpds Security Group - ${var.target_stack} - ${local.uniq_name}"
   }
 }
 
 
 resource "aws_security_group" "inbound-dictionary-from-wildfly" {
-  name        = "allow_inbound_from_dictionary_to_hpds_${var.stack_githash}"
+  name        = "allow_inbound_from_dictionary_to_hpds_${local.uniq_name}"
   description = "Allow inbound traffic from private-subnets on port 8080 for hpds"
   vpc_id      = local.target_vpc
 
@@ -74,13 +74,13 @@ resource "aws_security_group" "inbound-dictionary-from-wildfly" {
   tags = {
     Owner       = "Avillach_Lab"
     Environment = var.environment_name
-    Name        = "inbound-wildfly Security Group - ${var.target_stack} - ${var.stack_githash}"
+    Name        = "inbound-wildfly Security Group - ${var.target_stack} - ${local.uniq_name}"
   }
 }
 
 
 resource "aws_security_group" "inbound-mysql-from-wildfly" {
-  name        = "allow_inbound_from_wildfly_to_mysql_${var.stack_githash}"
+  name        = "allow_inbound_from_wildfly_to_mysql_${local.uniq_name}"
   description = "Allow inbound traffic from wildfly to mysql on port 3306"
   vpc_id      = local.target_vpc
 
@@ -95,14 +95,14 @@ resource "aws_security_group" "inbound-mysql-from-wildfly" {
   tags = {
     Owner       = "Avillach_Lab"
     Environment = var.environment_name
-    Name        = "inbound-mysql Security Group - ${var.target_stack} - ${var.stack_githash}"
+    Name        = "inbound-mysql Security Group - ${var.target_stack} - ${local.uniq_name}"
   }
 }
 
 
 ### Outbound
 resource "aws_security_group" "outbound-to-internet" {
-  name        = "allow_outbound_to_public_internet_${var.stack_githash}"
+  name        = "allow_outbound_to_public_internet_${local.uniq_name}"
   description = "Allow outbound traffic to public internet"
   vpc_id      = local.target_vpc
 
@@ -116,6 +116,6 @@ resource "aws_security_group" "outbound-to-internet" {
   tags = {
     Owner       = "Avillach_Lab"
     Environment = var.environment_name
-    Name        = "outbound-to-internet Security Group - ${var.target_stack} - ${var.stack_githash}"
+    Name        = "outbound-to-internet Security Group - ${var.target_stack} - ${local.uniq_name}"
   }
 }

--- a/app-infrastructure/wildfly-instance.tf
+++ b/app-infrastructure/wildfly-instance.tf
@@ -31,7 +31,7 @@ resource "aws_instance" "wildfly-ec2" {
 
   subnet_id = local.private2_subnet_ids[0]
 
-  iam_instance_profile = "wildfly-deployment-s3-profile-${var.target_stack}-${var.stack_githash}"
+  iam_instance_profile = "wildfly-deployment-s3-profile-${var.target_stack}-${local.uniq_name}"
 
   user_data = data.template_cloudinit_config.wildfly-user-data.rendered
 

--- a/app-infrastructure/wildfly-instance.tf
+++ b/app-infrastructure/wildfly-instance.tf
@@ -51,7 +51,7 @@ resource "aws_instance" "wildfly-ec2" {
     Environment = var.environment_name
     Project     = local.project
     Stack       = var.target_stack
-    Name        = "Wildfly - ${var.target_stack} - ${var.stack_githash}"
+    Name        = "Wildfly - ${var.target_stack} - ${local.uniq_name}"
   }
 
   metadata_options {


### PR DESCRIPTION
# Various fixes / improvements to infrastructure
* removed the reliance on passing the githash to use for naming resources.  No real reason to use the githash using a random string instead.  
* Bucket Policy for s3 stack bucket needed to be updated to handle dynamic naming of roles used to pull data to ec2 nodes during deployment.  A secure dynamic role is more flexible and doesn't need to be updated each deployment.
* The s3 bucket policy is not currently managed by this infrastructure code. 
* Updated the outputs to handle hpds ids for open and auth to be more fault tolerant.  Outputs could fail teardown destroy if no nodes were generated in the state file.  This change allows to recover from a bad state.