### PR TITLE
[ALS-5119] Update aggregate resource properties

### DIFF
--- a/app-infrastructure/configs/aggregate-resource.properties
+++ b/app-infrastructure/configs/aggregate-resource.properties
@@ -2,3 +2,4 @@ target.picsure.url=http://open-hpds.${target-stack}.datastage.hms.harvard.edu:80
 target.picsure.token=
 target.picsure.obfuscation_threshold=10
 target.picsure.obfuscation_variance=3
+visualization.resource.id=ca0ad4a9-130a-3a8a-ae00-e35b07f1108b


### PR DESCRIPTION
The aggregate resource needs the visualization ID in order to correctly format continuous queries.