### PR TITLE
Remove var prefix from terraform rendering

### DIFF
--- a/app-infrastructure/configs/pic-sure-schema.sql
+++ b/app-infrastructure/configs/pic-sure-schema.sql
@@ -103,7 +103,7 @@ CREATE TABLE `resource` (
 --
 LOCK TABLES `resource` WRITE;
 /*!40000 ALTER TABLE `resource` DISABLE KEYS */;
-${include_auth_hpds ? "INSERT INTO `resource` VALUES (0x02E23F52F3544E8B992CD37C8B9BA140,NULL,'http://auth-hpds.${var.target_stack}.${var.env_private_dns_name}:8080/PIC-SURE/','Authorized Access HPDS resource','auth-hpds',NULL, NULL, NULL);" : ""}
+${include_auth_hpds ? "INSERT INTO `resource` VALUES (0x02E23F52F3544E8B992CD37C8B9BA140,NULL,'http://auth-hpds.${target_stack}.${env_private_dns_name}:8080/PIC-SURE/','Authorized Access HPDS resource','auth-hpds',NULL, NULL, NULL);" : ""}
 ${include_open_hpds ? "INSERT INTO `resource` VALUES (0x70c837be5ffc11ebae930242ac130002,NULL,'http://localhost:8080/pic-sure-aggregate-resource/pic-sure/aggregate-data-sharing','Open Access (aggregate) resource','open-hpds',NULL, NULL, NULL);" : ""}
 INSERT INTO `resource` VALUES (0x36363664623161342d386538652d3131,NULL,'http://dictionary.${target_stack}.${env_private_dns_name}:8080/dictionary/pic-sure','Dictionary','dictionary',NULL, NULL, NULL);
 INSERT INTO `resource` VALUES (0xCA0AD4A9130A3A8AAE00E35B07F1108B,NULL,'http://localhost:8080/pic-sure-visualization-resource/pic-sure/visualization','Visualization','visualization',NULL, NULL, NULL);


### PR DESCRIPTION
# remove var from the prefix.
* No need for var for terraform rendering.