### PR TITLE
ALS-3951 - Added waiting for tagging init to HPDS Instances.  Various Cleanup.

### DIFF
--- a/app-infrastructure/configs/resources-registration.sql
+++ b/app-infrastructure/configs/resources-registration.sql
@@ -8,6 +8,42 @@ The resources are not stored in a dynamic fashion so they need to be upserted wi
 -- We have multiple stacks so we CANNOT use the same UUID for both if they are both reliant on the same RDS
 -- if we ever want to make this compatiable with other interfaces we must make resource configuration more abstract and dynamic. - TD
 /*!40000 ALTER TABLE `resource` DISABLE KEYS */;
-${include_auth_hpds ? "UPSERT INTO `resource` VALUES (0x02E23F52F3544E8B992CD37C8B9BA140,NULL,'http://auth-hpds.${target_stack}.${env_private_dns_name}:8080/PIC-SURE/','Authorized Access HPDS resource','auth-hpds',NULL, NULL, NULL);" : ""}
-UPSERT INTO `resource` VALUES (0x36363664623161342d386538652d3131,NULL,'http://dictionary.${target_stack}.${env_private_dns_name}:8080/dictionary/pic-sure','Dictionary','dictionary',NULL, NULL, NULL);
+${include_auth_hpds ? 
+  "INSERT INTO `resource` VALUES (
+    0x02E23F52F3544E8B992CD37C8B9BA140,
+    NULL,
+    'http://auth-hpds.${target_stack}.${env_private_dns_name}:8080/PIC-SURE/',
+    'Authorized Access HPDS resource',
+    'auth-hpds',
+    NULL,
+    NULL,
+    NULL
+  ) ON DUPLICATE KEY UPDATE `resourceRSPath` = VALUES(`resourceRSPath`);" : ""}
+
+INSERT INTO `resource`
+VALUES (
+  0x36363664623161342d386538652d3131,
+  NULL,
+  'http://dictionary.${target_stack}.${env_private_dns_name}:8080/dictionary/pic-sure',
+  'Dictionary',
+  'dictionary',
+  NULL,
+  NULL,
+  NULL
+) 
+ON DUPLICATE KEY UPDATE
+  `resourceRSPath` = VALUES(`resourceRSPath`);
 /*!40000 ALTER TABLE `resource` ENABLE KEYS */;
+INSERT INTO `resource`
+VALUES (
+  0x02E23F52F3544E8B992CD37C8B9BA140,
+  NULL,
+  'http://auth-hpds.a.dev.authpicsure.srce.hms.harvard.edu:8080/PIC-SURE/',
+  'Authorized Access HPDS resource',
+  'auth-hpds',
+  NULL,
+  NULL,
+  NULL
+) 
+ON DUPLICATE KEY UPDATE
+  targetURL = VALUES(targetURL); 

--- a/app-infrastructure/configs/resources-registration.sql
+++ b/app-infrastructure/configs/resources-registration.sql
@@ -4,6 +4,7 @@ The resources are not stored in a dynamic fashion so they need to be upserted wi
 
 **/
 
+USE `picsure`;
 -- Upsert to resources tables to handle stack hardcodings.
 -- We have multiple stacks so we CANNOT use the same UUID for both if they are both reliant on the same RDS
 -- if we ever want to make this compatiable with other interfaces we must make resource configuration more abstract and dynamic. - TD

--- a/app-infrastructure/configs/resources-registration.sql
+++ b/app-infrastructure/configs/resources-registration.sql
@@ -8,42 +8,6 @@ The resources are not stored in a dynamic fashion so they need to be upserted wi
 -- We have multiple stacks so we CANNOT use the same UUID for both if they are both reliant on the same RDS
 -- if we ever want to make this compatiable with other interfaces we must make resource configuration more abstract and dynamic. - TD
 /*!40000 ALTER TABLE `resource` DISABLE KEYS */;
-${include_auth_hpds ? 
-  "INSERT INTO `resource` VALUES (
-    0x02E23F52F3544E8B992CD37C8B9BA140,
-    NULL,
-    'http://auth-hpds.${target_stack}.${env_private_dns_name}:8080/PIC-SURE/',
-    'Authorized Access HPDS resource',
-    'auth-hpds',
-    NULL,
-    NULL,
-    NULL
-  ) ON DUPLICATE KEY UPDATE `resourceRSPath` = VALUES(`resourceRSPath`);" : ""}
-
-INSERT INTO `resource`
-VALUES (
-  0x36363664623161342d386538652d3131,
-  NULL,
-  'http://dictionary.${target_stack}.${env_private_dns_name}:8080/dictionary/pic-sure',
-  'Dictionary',
-  'dictionary',
-  NULL,
-  NULL,
-  NULL
-) 
-ON DUPLICATE KEY UPDATE
-  `resourceRSPath` = VALUES(`resourceRSPath`);
+${include_auth_hpds ? "UPSERT INTO `resource` VALUES (0x02E23F52F3544E8B992CD37C8B9BA140,NULL,'http://auth-hpds.${target_stack}.${env_private_dns_name}:8080/PIC-SURE/','Authorized Access HPDS resource','auth-hpds',NULL, NULL, NULL);" : ""}
+INSERT INTO `resource` VALUES (0x36363664623161342d386538652d3131, NULL, 'http://dictionary.${target_stack}.${env_private_dns_name}:8080/dictionary/pic-sure', 'Dictionary', 'dictionary', NULL, NULL, NULL) ON DUPLICATE KEY UPDATE `resourceRSPath` = VALUES(`resourceRSPath`);
 /*!40000 ALTER TABLE `resource` ENABLE KEYS */;
-INSERT INTO `resource`
-VALUES (
-  0x02E23F52F3544E8B992CD37C8B9BA140,
-  NULL,
-  'http://auth-hpds.a.dev.authpicsure.srce.hms.harvard.edu:8080/PIC-SURE/',
-  'Authorized Access HPDS resource',
-  'auth-hpds',
-  NULL,
-  NULL,
-  NULL
-) 
-ON DUPLICATE KEY UPDATE
-  targetURL = VALUES(targetURL); 

--- a/app-infrastructure/configs/resources-registration.sql
+++ b/app-infrastructure/configs/resources-registration.sql
@@ -1,0 +1,13 @@
+/**
+This script needs to run if an application is using a persistant application RDS
+The resources are not stored in a dynamic fashion so they need to be upserted with each deployment
+
+**/
+
+-- Upsert to resources tables to handle stack hardcodings.
+-- We have multiple stacks so we CANNOT use the same UUID for both if they are both reliant on the same RDS
+-- if we ever want to make this compatiable with other interfaces we must make resource configuration more abstract and dynamic. - TD
+/*!40000 ALTER TABLE `resource` DISABLE KEYS */;
+${include_auth_hpds ? "UPSERT INTO `resource` VALUES (0x02E23F52F3544E8B992CD37C8B9BA140,NULL,'http://auth-hpds.${target_stack}.${env_private_dns_name}:8080/PIC-SURE/','Authorized Access HPDS resource','auth-hpds',NULL, NULL, NULL);" : ""}
+UPSERT INTO `resource` VALUES (0x36363664623161342d386538652d3131,NULL,'http://dictionary.${target_stack}.${env_private_dns_name}:8080/dictionary/pic-sure','Dictionary','dictionary',NULL, NULL, NULL);
+/*!40000 ALTER TABLE `resource` ENABLE KEYS */;

--- a/app-infrastructure/configs/resources-registration.sql
+++ b/app-infrastructure/configs/resources-registration.sql
@@ -8,6 +8,6 @@ The resources are not stored in a dynamic fashion so they need to be upserted wi
 -- We have multiple stacks so we CANNOT use the same UUID for both if they are both reliant on the same RDS
 -- if we ever want to make this compatiable with other interfaces we must make resource configuration more abstract and dynamic. - TD
 /*!40000 ALTER TABLE `resource` DISABLE KEYS */;
-${include_auth_hpds ? "UPSERT INTO `resource` VALUES (0x02E23F52F3544E8B992CD37C8B9BA140,NULL,'http://auth-hpds.${target_stack}.${env_private_dns_name}:8080/PIC-SURE/','Authorized Access HPDS resource','auth-hpds',NULL, NULL, NULL);" : ""}
+${include_auth_hpds ? "INSERT INTO `resource` VALUES (0x02E23F52F3544E8B992CD37C8B9BA140,NULL,'http://auth-hpds.${target_stack}.${env_private_dns_name}:8080/PIC-SURE/','Authorized Access HPDS resource','auth-hpds',NULL, NULL, NULL) ON DUPLICATE KEY UPDATE `resourceRSPath` = VALUES(`resourceRSPath`);" : ""}
 INSERT INTO `resource` VALUES (0x36363664623161342d386538652d3131, NULL, 'http://dictionary.${target_stack}.${env_private_dns_name}:8080/dictionary/pic-sure', 'Dictionary', 'dictionary', NULL, NULL, NULL) ON DUPLICATE KEY UPDATE `resourceRSPath` = VALUES(`resourceRSPath`);
 /*!40000 ALTER TABLE `resource` ENABLE KEYS */;

--- a/app-infrastructure/picsure-db.tf
+++ b/app-infrastructure/picsure-db.tf
@@ -64,6 +64,6 @@ data "template_file" "resources-registration" {
 }
 
 resource "local_file" "resources-registration-file" {
-  content  = data.template_file.pic-sure-schema-sql.rendered
+  content  = data.template_file.resources-registration.rendered
   filename = "resources-registration.sql"
 }

--- a/app-infrastructure/picsure-db.tf
+++ b/app-infrastructure/picsure-db.tf
@@ -29,3 +29,41 @@ resource "random_password" "picsure-db-password" {
   length  = 16
   special = false
 }
+
+data "template_file" "pic-sure-schema-sql" {
+  template = file("configs/pic-sure-schema.sql")
+  vars = {
+    picsure_token_introspection_token = var.picsure_token_introspection_token
+    target_stack                      = var.target_stack
+    env_private_dns_name              = var.env_private_dns_name
+    include_auth_hpds                 = var.include_auth_hpds
+    include_open_hpds                 = var.include_open_hpds
+  }
+}
+
+resource "local_file" "pic-sure-schema-sql-file" {
+  content  = data.template_file.pic-sure-schema-sql.rendered
+  filename = "pic-sure-schema.sql"
+}
+
+# Need to handle if the a stack is using a the hardcoded urls for resources in the db.
+# Upserts on deployments will at least ensure a newly deployed stack is using the correct urls for resources
+# This will not be a good methodology for standalone as each stack cannot use the same UUID. 
+# Need a more dynamic and abstract method to find resources instead of hardcoding them into config files.
+# Another table with simple uniq names that app can configure to lookup the UUIDs.
+# 
+data "template_file" "resources-registration" {
+  template = file("configs/resources-registration.sql")
+  vars = {
+    picsure_token_introspection_token = var.picsure_token_introspection_token
+    target_stack                      = var.target_stack
+    env_private_dns_name              = var.env_private_dns_name
+    include_auth_hpds                 = var.include_auth_hpds
+    include_open_hpds                 = var.include_open_hpds
+  }
+}
+
+resource "local_file" "resources-registration-file" {
+  content  = data.template_file.pic-sure-schema-sql.rendered
+  filename = "resources-registration.sql"
+}

--- a/app-infrastructure/s3_roles.tf
+++ b/app-infrastructure/s3_roles.tf
@@ -40,7 +40,13 @@ resource "aws_iam_role_policy" "wildfly-deployment-s3-policy" {
         "s3:GetObject"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:s3:::${var.stack_s3_bucket}/configs/jenkins_pipeline_build_${var.stack_githash_long}/pic-sure-schema.sql"
+      "Resource": "arn:aws:s3:::${var.stack_s3_bucket}/configs/jenkins_pipeline_build_${var.stack_githash_long}/resources-registration.sql"
+    },{
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${var.stack_s3_bucket}/configs/jenkins_pipeline_build_${var.stack_githash_long}/aggregate-resource.properties"
     },{
       "Action": [
         "s3:GetObject"

--- a/app-infrastructure/s3_roles.tf
+++ b/app-infrastructure/s3_roles.tf
@@ -46,6 +46,12 @@ resource "aws_iam_role_policy" "wildfly-deployment-s3-policy" {
         "s3:GetObject"
       ],
       "Effect": "Allow",
+      "Resource": "arn:aws:s3:::${var.stack_s3_bucket}/configs/jenkins_pipeline_build_${var.stack_githash_long}/*"
+    },{
+      "Action": [
+        "s3:GetObject"
+      ],
+      "Effect": "Allow",
       "Resource": "arn:aws:s3:::${var.stack_s3_bucket}/configs/jenkins_pipeline_build_${var.stack_githash_long}/aggregate-resource.properties"
     },{
       "Action": [

--- a/app-infrastructure/scripts/auth_hpds-user_data.sh
+++ b/app-infrastructure/scripts/auth_hpds-user_data.sh
@@ -31,8 +31,11 @@ cd /opt/local/hpds
 tar -xvzf javabins_rekeyed.tar.gz
 cd ~
 
+
+CONTAINER_NAME="auth-hpds"
+
 HPDS_IMAGE=`sudo docker load < /home/centos/pic-sure-hpds.tar.gz | cut -d ' ' -f 3`
-sudo docker run --name=auth-hpds \
+sudo docker run --name=$CONTAINER_NAME \
                 --restart unless-stopped \
                 --log-driver syslog --log-opt tag=auth-hpds \
                 -v /opt/local/hpds:/opt/local/hpds \
@@ -40,5 +43,33 @@ sudo docker run --name=auth-hpds \
                 -e CATALINA_OPTS=" -XX:+UseParallelGC -XX:SurvivorRatio=250 -Xms10g -Xmx110g -DCACHE_SIZE=2500 -DSMALL_TASK_THREADS=1 -DLARGE_TASK_THREADS=1 -DSMALL_JOB_LIMIT=100 -DID_BATCH_SIZE=5000 '-DALL_IDS_CONCEPT=NONE'  '-DID_CUBE_NAME=NONE'"  \
                 -d $HPDS_IMAGE
 
-INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
-sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $${INSTANCE_ID} --tags Key=InitComplete,Value=true
+
+# Waiting for application to finish initialization
+INIT_MESSAGE="ContextLoader:344 - Root WebApplicationContext: initialization completed"
+INIT_TIMEOUT_SEX=2400  # Set your desired timeout in seconds
+INIT_START_TIME=$(date +%s)
+
+while [ true ]; do
+  if docker logs --tail 0 --follow "$CONTAINER_NAME" | grep -q "$INIT_MESSAGE"; then
+    echo "$CONTAINER_NAME container has initialized."
+    
+    INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
+    sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=true
+
+    break
+  fi
+  
+  # Timeout 
+  CURRENT_TIME=$(date +%s)
+  ELAPSED_TIME=$((CURRENT_TIME - INIT_START_TIME))
+
+  if [ "$ELAPSED_TIME" -ge "$INIT_TIMEOUT_SEX" ]; then
+    echo "Timeout reached ($INIT_TIMEOUT_SEX seconds). The $CONTAINER_NAME container initialization didn't complete."
+    INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
+    sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=failed
+
+    break
+  else
+    sleep 20
+  fi
+done

--- a/app-infrastructure/scripts/auth_hpds-user_data.sh
+++ b/app-infrastructure/scripts/auth_hpds-user_data.sh
@@ -43,23 +43,17 @@ sudo docker run --name=$CONTAINER_NAME \
                 -e CATALINA_OPTS=" -XX:+UseParallelGC -XX:SurvivorRatio=250 -Xms10g -Xmx110g -DCACHE_SIZE=2500 -DSMALL_TASK_THREADS=1 -DLARGE_TASK_THREADS=1 -DSMALL_JOB_LIMIT=100 -DID_BATCH_SIZE=5000 '-DALL_IDS_CONCEPT=NONE'  '-DID_CUBE_NAME=NONE'"  \
                 -d $HPDS_IMAGE
 
-
 # Waiting for application to finish initialization
 INIT_MESSAGE="WebApplicationContext: initialization completed"
 INIT_TIMEOUT_SEX=2400  # Set your desired timeout in seconds
 INIT_START_TIME=$(date +%s)
 
-while [ true ]; do
-  if docker logs --tail 0 --follow "$CONTAINER_NAME" | grep -q "$INIT_MESSAGE"; then
-    echo "$CONTAINER_NAME container has initialized."
-    
-    INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
-    sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=true
+while docker logs "$CONTAINER_NAME" 2>&1 | grep "$INIT_MESSAGE"; do
+  echo "$CONTAINER_NAME container has initialized."
 
-    break
-  fi
-  
-  # Timeout 
+  INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
+  sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=true
+
   CURRENT_TIME=$(date +%s)
   ELAPSED_TIME=$((CURRENT_TIME - INIT_START_TIME))
 

--- a/app-infrastructure/scripts/auth_hpds-user_data.sh
+++ b/app-infrastructure/scripts/auth_hpds-user_data.sh
@@ -45,7 +45,7 @@ sudo docker run --name=$CONTAINER_NAME \
 
 
 # Waiting for application to finish initialization
-INIT_MESSAGE="ContextLoader:344 - Root WebApplicationContext: initialization completed"
+INIT_MESSAGE="WebApplicationContext: initialization completed"
 INIT_TIMEOUT_SEX=2400  # Set your desired timeout in seconds
 INIT_START_TIME=$(date +%s)
 

--- a/app-infrastructure/scripts/auth_hpds-user_data.sh
+++ b/app-infrastructure/scripts/auth_hpds-user_data.sh
@@ -31,6 +31,11 @@ cd /opt/local/hpds
 tar -xvzf javabins_rekeyed.tar.gz
 cd ~
 
+# Load and run docker container.  Then wait for initialization before tagging instance as init complete.
+echo "Loading and running docker container"
+INIT_MESSAGE="WebApplicationContext: initialization completed"
+INIT_TIMEOUT_SECS=2400  # Set your desired timeout in seconds
+INIT_START_TIME=$(date +%s)
 
 CONTAINER_NAME="auth-hpds"
 
@@ -43,27 +48,26 @@ sudo docker run --name=$CONTAINER_NAME \
                 -e CATALINA_OPTS=" -XX:+UseParallelGC -XX:SurvivorRatio=250 -Xms10g -Xmx110g -DCACHE_SIZE=2500 -DSMALL_TASK_THREADS=1 -DLARGE_TASK_THREADS=1 -DSMALL_JOB_LIMIT=100 -DID_BATCH_SIZE=5000 '-DALL_IDS_CONCEPT=NONE'  '-DID_CUBE_NAME=NONE'"  \
                 -d $HPDS_IMAGE
 
-# Waiting for application to finish initialization
-INIT_MESSAGE="WebApplicationContext: initialization completed"
-INIT_TIMEOUT_SEX=2400  # Set your desired timeout in seconds
-INIT_START_TIME=$(date +%s)
+echo "Waiting for container to initialize"
+while true; do
+  status=$(docker logs "$CONTAINER_NAME" 2>&1 | grep "$INIT_MESSAGE")
 
-while docker logs "$CONTAINER_NAME" 2>&1 | grep "$INIT_MESSAGE"; do
-  echo "$CONTAINER_NAME container has initialized."
+  if [ -z $status ];then
+    echo "$CONTAINER_NAME container has initialized."
 
-  INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
-  sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=true
-
-  CURRENT_TIME=$(date +%s)
-  ELAPSED_TIME=$((CURRENT_TIME - INIT_START_TIME))
-
-  if [ "$ELAPSED_TIME" -ge "$INIT_TIMEOUT_SEX" ]; then
-    echo "Timeout reached ($INIT_TIMEOUT_SEX seconds). The $CONTAINER_NAME container initialization didn't complete."
     INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
-    sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=failed
-
+    sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=true
     break
   else
-    sleep 20
+    CURRENT_TIME=$(date +%s)
+    ELAPSED_TIME=$((CURRENT_TIME - INIT_START_TIME))
+
+    if [ "$ELAPSED_TIME" -ge "$INIT_TIMEOUT_SECS" ]; then
+      echo "Timeout reached ($INIT_TIMEOUT_SECS seconds). The $CONTAINER_NAME container initialization didn't complete."
+      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
+      sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=failed
+
+      break
+    fi
   fi
 done

--- a/app-infrastructure/scripts/httpd-user_data.sh
+++ b/app-infrastructure/scripts/httpd-user_data.sh
@@ -24,7 +24,7 @@ s3_copy() {
     sudo /usr/bin/aws --region us-east-1 s3 cp $* && break || sleep 30
   done
 }
-# sleep for awhile because as these files could still be in the process of being rendered.
+# sleep for awhile as these files could still be in the process of being rendered.
 echo "waiting for terraform to render files"
 sleep 1200
 

--- a/app-infrastructure/scripts/httpd-user_data.sh
+++ b/app-infrastructure/scripts/httpd-user_data.sh
@@ -24,6 +24,10 @@ s3_copy() {
     sudo /usr/bin/aws --region us-east-1 s3 cp $* && break || sleep 30
   done
 }
+# sleep for awhile because as these files are could still be in the process of being rendered.
+# containerize already.
+echo "waiting for terraform to render files"
+sleep 2400
 
 s3_copy s3://${stack_s3_bucket}/releases/jenkins_pipeline_build_${stack_githash}/pic-sure-ui.tar.gz /home/centos/pic-sure-ui.tar.gz
 s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/httpd-vhosts.conf /usr/local/docker-config/httpd-vhosts.conf

--- a/app-infrastructure/scripts/httpd-user_data.sh
+++ b/app-infrastructure/scripts/httpd-user_data.sh
@@ -24,10 +24,9 @@ s3_copy() {
     sudo /usr/bin/aws --region us-east-1 s3 cp $* && break || sleep 30
   done
 }
-# sleep for awhile because as these files are could still be in the process of being rendered.
-# containerize already.
+# sleep for awhile because as these files could still be in the process of being rendered.
 echo "waiting for terraform to render files"
-sleep 2400
+sleep 1200
 
 s3_copy s3://${stack_s3_bucket}/releases/jenkins_pipeline_build_${stack_githash}/pic-sure-ui.tar.gz /home/centos/pic-sure-ui.tar.gz
 s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/httpd-vhosts.conf /usr/local/docker-config/httpd-vhosts.conf

--- a/app-infrastructure/scripts/open_hpds-user_data.sh
+++ b/app-infrastructure/scripts/open_hpds-user_data.sh
@@ -30,35 +30,42 @@ cd /opt/local/hpds
 tar -xvzf destigmatized_javabins_rekeyed.tar.gz
 cd ~
 
-HPDS_IMAGE=`sudo docker load < /home/centos/pic-sure-hpds.tar.gz | cut -d ' ' -f 3`
-sudo docker run --name=open-hpds \
-                --restart unless-stopped \
-                --log-driver syslog --log-opt tag=open-hpds \
-                -v /opt/local/hpds:/opt/local/hpds -p 8080:8080 \
-                -e CATALINA_OPTS=" -XX:+UseParallelGC -XX:SurvivorRatio=250 -Xms10g -Xmx40g -DCACHE_SIZE=2500 -DSMALL_TASK_THREADS=1 -DLARGE_TASK_THREADS=1 -DSMALL_JOB_LIMIT=100 -DID_BATCH_SIZE=5000 " \
-                -d $HPDS_IMAGE
-
 # Waiting for application to finish initialization
 INIT_MESSAGE="WebApplicationContext: initialization completed"
 INIT_TIMEOUT_SEX=2400  # Set your desired timeout in seconds
 INIT_START_TIME=$(date +%s)
 
-while docker logs "$CONTAINER_NAME" 2>&1 | grep "$INIT_MESSAGE"; do
-  echo "$CONTAINER_NAME container has initialized."
+CONTAINER_NAME="open-hpds"
 
-  INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
-  sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=true
+HPDS_IMAGE=`sudo docker load < /home/centos/pic-sure-hpds.tar.gz | cut -d ' ' -f 3`
+sudo docker run --name=$CONTAINER_NAME \
+                --restart unless-stopped \
+                --log-driver syslog --log-opt tag=open-hpds \
+                -v /opt/local/hpds:/opt/local/hpds \
+                -p 8080:8080 \
+                -e CATALINA_OPTS=" -XX:+UseParallelGC -XX:SurvivorRatio=250 -Xms10g -Xmx40g -DCACHE_SIZE=2500 -DSMALL_TASK_THREADS=1 -DLARGE_TASK_THREADS=1 -DSMALL_JOB_LIMIT=100 -DID_BATCH_SIZE=5000 " \
+                -d $HPDS_IMAGE
 
-  CURRENT_TIME=$(date +%s)
-  ELAPSED_TIME=$((CURRENT_TIME - INIT_START_TIME))
+echo "Waiting for container to initialize"
+while true; do
+  status=$(docker logs "$CONTAINER_NAME" 2>&1 | grep "$INIT_MESSAGE")
 
-  if [ "$ELAPSED_TIME" -ge "$INIT_TIMEOUT_SEX" ]; then
-    echo "Timeout reached ($INIT_TIMEOUT_SEX seconds). The $CONTAINER_NAME container initialization didn't complete."
+  if [ -z $status ];then
+    echo "$CONTAINER_NAME container has initialized."
+
     INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
-    sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=failed
-
+    sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=true
     break
   else
-    sleep 20
+    CURRENT_TIME=$(date +%s)
+    ELAPSED_TIME=$((CURRENT_TIME - INIT_START_TIME))
+
+    if [ "$ELAPSED_TIME" -ge "$INIT_TIMEOUT_SECS" ]; then
+      echo "Timeout reached ($INIT_TIMEOUT_SECS seconds). The $CONTAINER_NAME container initialization didn't complete."
+      INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
+      sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=failed
+
+      break
+    fi
   fi
 done

--- a/app-infrastructure/scripts/open_hpds-user_data.sh
+++ b/app-infrastructure/scripts/open_hpds-user_data.sh
@@ -38,5 +38,32 @@ sudo docker run --name=open-hpds \
                 -e CATALINA_OPTS=" -XX:+UseParallelGC -XX:SurvivorRatio=250 -Xms10g -Xmx40g -DCACHE_SIZE=2500 -DSMALL_TASK_THREADS=1 -DLARGE_TASK_THREADS=1 -DSMALL_JOB_LIMIT=100 -DID_BATCH_SIZE=5000 " \
                 -d $HPDS_IMAGE
 
-INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
-sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $${INSTANCE_ID} --tags Key=InitComplete,Value=true
+# Waiting for application to finish initialization
+INIT_MESSAGE="WebApplicationContext: initialization completed"
+INIT_TIMEOUT_SEX=2400  # Set your desired timeout in seconds
+INIT_START_TIME=$(date +%s)
+
+while [ true ]; do
+  if docker logs --tail 0 --follow "$CONTAINER_NAME" | grep -q "$INIT_MESSAGE"; then
+    echo "$CONTAINER_NAME container has initialized."
+    
+    INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
+    sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=true
+
+    break
+  fi
+  
+  # Timeout 
+  CURRENT_TIME=$(date +%s)
+  ELAPSED_TIME=$((CURRENT_TIME - INIT_START_TIME))
+
+  if [ "$ELAPSED_TIME" -ge "$INIT_TIMEOUT_SEX" ]; then
+    echo "Timeout reached ($INIT_TIMEOUT_SEX seconds). The $CONTAINER_NAME container initialization didn't complete."
+    INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
+    sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=failed
+
+    break
+  else
+    sleep 20
+  fi
+done

--- a/app-infrastructure/scripts/wildfly-user_data.sh
+++ b/app-infrastructure/scripts/wildfly-user_data.sh
@@ -26,6 +26,10 @@ s3_copy() {
     sudo /usr/bin/aws --region us-east-1 s3 cp $* && break || sleep 30
   done
 }
+# sleep for awhile because as these files are could still be in the process of being rendered.
+# containerize already.
+echo "waiting for terraform to render files"
+sleep 600
 
 s3_copy s3://${stack_s3_bucket}/releases/jenkins_pipeline_build_${stack_githash}/pic-sure-wildfly.tar.gz /home/centos/pic-sure-wildfly.tar.gz
 s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/standalone.xml /home/centos/standalone.xml

--- a/app-infrastructure/scripts/wildfly-user_data.sh
+++ b/app-infrastructure/scripts/wildfly-user_data.sh
@@ -65,4 +65,4 @@ sudo docker run -u root --name=$CONTAINER_NAME \
 
 
 INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
-
+sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $INSTANCE_ID --tags Key=InitComplete,Value=true

--- a/app-infrastructure/scripts/wildfly-user_data.sh
+++ b/app-infrastructure/scripts/wildfly-user_data.sh
@@ -30,19 +30,25 @@ s3_copy() {
 s3_copy s3://${stack_s3_bucket}/releases/jenkins_pipeline_build_${stack_githash}/pic-sure-wildfly.tar.gz /home/centos/pic-sure-wildfly.tar.gz
 s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/standalone.xml /home/centos/standalone.xml
 s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/pic-sure-schema.sql /home/centos/pic-sure-schema.sql
+s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/resources-registration.sql /home/centos/resources-registration.sql
 s3_copy s3://${stack_s3_bucket}/modules/mysql/module.xml /home/centos/mysql_module.xml
 s3_copy s3://${stack_s3_bucket}/modules/mysql/mysql-connector-java-5.1.38.jar /home/centos/mysql-connector-java-5.1.38.jar
 s3_copy s3://${stack_s3_bucket}/data/${dataset_s3_object_key}/fence_mapping.json /home/centos/fence_mapping.json
 s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/aggregate-resource.properties /home/centos/aggregate-resource.properties
 s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/visualization-resource.properties /home/centos/visualization-resource.properties
 
+# if no snapshot db will be empty use this to atleast initialize it somewhere for now. - TD
 if [ -z ${picsure_rds_snapshot_id} ]; then
   sudo docker run  -d --name schema-init -e "MYSQL_RANDOM_ROOT_PASSWORD=yes" --rm mysql
   sudo docker exec -i schema-init mysql -hpicsure-db.${target_stack}.${env_private_dns_name} -uroot -p${mysql-instance-password} < /home/centos/pic-sure-schema.sql
   sudo docker stop schema-init
   echo "init'd mysql schemas"
+else
+# if snapshot of production is used we need to configure stack rds resource table with deployed stacks resources.
+# We cannot and should not be doing CORS between stacks. -TD
+  sudo docker run  -d --name schema-init -e "MYSQL_RANDOM_ROOT_PASSWORD=yes" --rm mysql
+  sudo docker exec -i schema-init mysql -hpicsure-db.${target_stack}.${env_private_dns_name} -uroot -p${mysql-instance-password} < /home/centos/pic-sure-schema.sql
 fi
-
 WILDFLY_IMAGE=`sudo docker load < /home/centos/pic-sure-wildfly.tar.gz | cut -d ' ' -f 3`
 JAVA_OPTS="-Xms2g -Xmx26g -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=1024m -Djava.net.preferIPv4Stack=true"
 

--- a/app-infrastructure/scripts/wildfly-user_data.sh
+++ b/app-infrastructure/scripts/wildfly-user_data.sh
@@ -40,7 +40,7 @@ s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/
 # if no snapshot db will be empty use this to atleast initialize it somewhere for now. - TD
 if [ -z ${picsure_rds_snapshot_id} ]; then
   sudo docker run  -d --name schema-init -e "MYSQL_RANDOM_ROOT_PASSWORD=yes" --rm mysql
-  sudo docker exec -i schema-init mysql -hpicsure-db.${target_stack}.${env_private_dns_name} -uroot -p${mysql-instance-password} < /home/centos/pic-sure-schema.sql
+  sudo docker exec -i schema-init mysql -hpicsure-db.${target_stack}.${env_private_dns_name} -uroot -p${mysql-instance-password} < /home/centos/resources-registration.sql
   sudo docker stop schema-init
   echo "init'd mysql schemas"
 else

--- a/app-infrastructure/scripts/wildfly-user_data.sh
+++ b/app-infrastructure/scripts/wildfly-user_data.sh
@@ -36,7 +36,7 @@ s3_copy s3://${stack_s3_bucket}/data/${dataset_s3_object_key}/fence_mapping.json
 s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/aggregate-resource.properties /home/centos/aggregate-resource.properties
 s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/visualization-resource.properties /home/centos/visualization-resource.properties
 
-if [ -z $picsure_rds_snapshot_id ]; then
+if [ -z ${picsure_rds_snapshot_id} ]; then
   sudo docker run  -d --name schema-init -e "MYSQL_RANDOM_ROOT_PASSWORD=yes" --rm mysql
   sudo docker exec -i schema-init mysql -hpicsure-db.${target_stack}.${env_private_dns_name} -uroot -p${mysql-instance-password} < /home/centos/pic-sure-schema.sql
   sudo docker stop schema-init

--- a/app-infrastructure/scripts/wildfly-user_data.sh
+++ b/app-infrastructure/scripts/wildfly-user_data.sh
@@ -44,7 +44,7 @@ if [ -z ${picsure_rds_snapshot_id} ]; then
   sudo docker stop schema-init
   echo "init'd mysql schemas"
 else
-# if snapshot of production is used we need to configure stack rds resource table with deployed stacks resources.
+# if snapshot of live stack rds is used we need to configure target stack rds resource table with deployed stacks resources.
 # We cannot and should not be doing CORS between stacks. -TD
   sudo docker run  -d --name schema-init -e "MYSQL_RANDOM_ROOT_PASSWORD=yes" --rm mysql
   sudo docker exec -i schema-init mysql -hpicsure-db.${target_stack}.${env_private_dns_name} -uroot -p${mysql-instance-password} < /home/centos/pic-sure-schema.sql

--- a/app-infrastructure/scripts/wildfly-user_data.sh
+++ b/app-infrastructure/scripts/wildfly-user_data.sh
@@ -40,15 +40,18 @@ s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/
 # if no snapshot db will be empty use this to atleast initialize it somewhere for now. - TD
 if [ -z ${picsure_rds_snapshot_id} ]; then
   sudo docker run  -d --name schema-init -e "MYSQL_RANDOM_ROOT_PASSWORD=yes" --rm mysql
-  sudo docker exec -i schema-init mysql -hpicsure-db.${target_stack}.${env_private_dns_name} -uroot -p${mysql-instance-password} < /home/centos/resources-registration.sql
+  sudo docker exec -i schema-init mysql -hpicsure-db.${target_stack}.${env_private_dns_name} -uroot -p${mysql-instance-password} < /home/centos/pic-sure-schema.sql
   sudo docker stop schema-init
   echo "init'd mysql schemas"
 else
 # if snapshot of live stack rds is used we need to configure target stack rds resource table with deployed stacks resources.
 # We cannot and should not be doing CORS between stacks. -TD
   sudo docker run  -d --name schema-init -e "MYSQL_RANDOM_ROOT_PASSWORD=yes" --rm mysql
-  sudo docker exec -i schema-init mysql -hpicsure-db.${target_stack}.${env_private_dns_name} -uroot -p${mysql-instance-password} < /home/centos/pic-sure-schema.sql
+  sudo docker exec -i schema-init mysql -hpicsure-db.${target_stack}.${env_private_dns_name} -uroot -p${mysql-instance-password} < /home/centos/resources-registration.sql
+  sudo docker stop schema-init
+  echo "updated resources"
 fi
+
 WILDFLY_IMAGE=`sudo docker load < /home/centos/pic-sure-wildfly.tar.gz | cut -d ' ' -f 3`
 JAVA_OPTS="-Xms2g -Xmx26g -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=1024m -Djava.net.preferIPv4Stack=true"
 

--- a/app-infrastructure/wildfly-instance.tf
+++ b/app-infrastructure/wildfly-instance.tf
@@ -87,23 +87,6 @@ resource "local_file" "wildfly-standalone-xml-file" {
   filename = "standalone.xml"
 }
 
-data "template_file" "pic-sure-schema-sql" {
-  template = file("configs/pic-sure-schema.sql")
-  vars = {
-    picsure_token_introspection_token = var.picsure_token_introspection_token
-    target_stack                      = var.target_stack
-    env_private_dns_name              = var.env_private_dns_name
-    include_auth_hpds                 = var.include_auth_hpds
-    include_open_hpds                 = var.include_open_hpds
-  }
-}
-
-resource "local_file" "pic-sure-schema-sql-file" {
-  content  = data.template_file.pic-sure-schema-sql.rendered
-  filename = "pic-sure-schema.sql"
-}
-
-
 data "template_file" "aggregate-resource-properties" {
   template = file("configs/aggregate-resource.properties")
   vars = {


### PR DESCRIPTION
# HPDS Instances will now wait for the container to be initialized before tagging
* Updated hpds userscripts to monitor the docker log to wait for container to initialize.
* Moved some sql scripts to the picsuredb resource.  Bit better home for them.
* Updated s3 roles to allow configs to be pulled without having to continually update s3 roles.
* s3 roles will need a follow up tickets to clean out all the outdates statements.  Bit out of scope for this ticket.
* Had critical issue pop up during this work.  Need to update the deployed hpds with it's stack resources.