### PR TITLE
[ALS-2668] Add XSS protection in httpd-vhosts config

### DIFF
--- a/app-infrastructure/configs/httpd-vhosts.conf
+++ b/app-infrastructure/configs/httpd-vhosts.conf
@@ -147,6 +147,10 @@ ServerTokens Prod
     # A fall back for legacy browsers that don't yet support CSP frame-ancestors.
     Header always set X-Frame-Options "DENY"
 
+    # Enables built-in XSS protection in modern web browsers.
+    # If a XSS is detected mode=block will block the entire page.
+    Header always set X-XSS-Protection "1; mode=block;"
+
     RewriteEngine On
     ProxyPreserveHost On
 


### PR DESCRIPTION
[ALS-2668] The httpd-vhosts.conf configuration file now includes an option for built-in XSS protection supported by modern web browsers. It is set to block the entire page if a Cross-Site Scripting (XSS) attack is detected. This header already exists in our frontend harness and previously existed in the UI vhost files.