### PR TITLE
[ALS-6080] Update resource INSERT statements in V2__Insert_Resources.sql

### DIFF
--- a/app-infrastructure/configs/standalone.xml
+++ b/app-infrastructure/configs/standalone.xml
@@ -524,6 +524,9 @@
                 <simple name="java:global/fence_client_secret" value="${fence_client_secret}"/>
                 <simple name="java:global/fence_redirect_url" value="https://${env_public_dns_name}/psamaui/login/"/>
 
+                <!-- Used in BDC to determine the applications stack a, b, c, etc. -->
+                <simple name="java:global/application_stack" value="${target_stack}"/>
+
                 <simple name="java:global/fence_standard_access_rules"
                         value="AR_ONLY_INFO,AR_ONLY_SEARCH,AR_INFO_COLUMN_LISTING"/>
                 <simple name="java:global/fence_allowed_query_types"

--- a/app-infrastructure/db/picsure/V2__Insert_Resources.sql
+++ b/app-infrastructure/db/picsure/V2__Insert_Resources.sql
@@ -2,28 +2,28 @@
 INSERT INTO `resource`
 VALUES (0xCA0AD4A9130A3A8AAE00E35B07F1108B, NULL,
         'http://localhost:8080/pic-sure-visualization-resource/pic-sure/visualization', 'Visualization',
-        'visualization', NULL, NULL, NULL);
+        'visualization', NULL, false, NULL);
 INSERT INTO `resource`
 VALUES (0x70c837be5ffc11ebae930242ac130002, NULL,
         'http://localhost:8080/pic-sure-aggregate-resource/pic-sure/aggregate-data-sharing',
-        'Open Access (aggregate) resource', 'open-hpds', NULL, NULL, NULL);
+        'Open Access (aggregate) resource', 'open-hpds', NULL, ${include_open_hpds}, NULL);
 
 -- For both Auth HPDS and the Dictionary, we need to include the target_stack and env_private_dns_name variables in the URL.
 -- This requires two separate resources for each, one for the Auth HPDS and one for the Dictionary.
 INSERT INTO `resource`
 VALUES (unhex(REPLACE('02e23f52-f354-4e8b-992c-d37c8b9ba140', '-', '')), NULL,
         'http://auth-hpds.a.${env_private_dns_name}:8080/PIC-SURE/', 'Authorized Access HPDS resource', 'auth-hpds',
-        NULL, NULL, NULL);
+        NULL, ${include_auth_hpds}, NULL);
 INSERT INTO `resource`
 VALUES (unhex(REPLACE('9e765d93-49a9-42a5-884b-412a6a44af81', '-', '')), NULL,
         'http://auth-hpds.b.${env_private_dns_name}:8080/PIC-SURE/', 'Authorized Access HPDS resource', 'auth-hpds',
-        NULL, NULL, NULL);
+        NULL, ${include_auth_hpds}, NULL);
 
 INSERT INTO `resource`
 VALUES (unhex(REPLACE('4c6e53d0-0860-4129-9bbd-568b18833f98', '-', '')), NULL,
-        'http://dictionary.a.${env_private_dns_name}:8080/dictionary/pic-sure', 'Dictionary', 'dictionary', NULL, NULL,
+        'http://dictionary.a.${env_private_dns_name}:8080/dictionary/pic-sure', 'Dictionary', 'dictionary', NULL, true,
         NULL);
 INSERT INTO `resource`
 VALUES (unhex(REPLACE('36363664-6231-6134-2d38-6538652d3131', '-', '')), NULL,
-        'http://dictionary.b.${env_private_dns_name}:8080/dictionary/pic-sure', 'Dictionary', 'dictionary', NULL, NULL,
+        'http://dictionary.b.${env_private_dns_name}:8080/dictionary/pic-sure', 'Dictionary', 'dictionary', NULL, true,
         NULL);


### PR DESCRIPTION
The resource INSERT statements in the V2__Insert_Resources.sql file were updated. Specifically, modifications include the inclusion of variables to set access parameters for each resource type. Additionally, an 'application_stack' setting has been added to the standalone.xml for BDC application stack determination.