### PR TITLE
[ALS-5387] Replace variables with hardcoded IDs in configs

### DIFF
--- a/app-infrastructure/configs/picsureui_settings.json
+++ b/app-infrastructure/configs/picsureui_settings.json
@@ -8,10 +8,10 @@
     }
   ],
   "queryExportType": "EXPORT_ASYNC",
-  "picSureResourceId": "${auth_hpds_resource_id}",
+  "picSureResourceId": "02e23f52-f354-4e8b-992c-d37c8b9ba140",
   "openAccessResourceId": "70c837be-5ffc-11eb-ae93-0242ac130002",
   "visualizationResourceId": "ca0ad4a9-130a-3a8a-ae00-e35b07f1108b",
-  "dictionaryResourceId": "${dictionary_resource_id}",
+  "dictionaryResourceId": "36363664-6231-6134-2d38-6538652d3131",
   "applicationIdForBaseQuery": "${application_id_for_base_query}",
   "helpLink": "${help_link}",
   "loginLink": "${login_link}",

--- a/app-infrastructure/configs/visualization-resource.properties
+++ b/app-infrastructure/configs/visualization-resource.properties
@@ -1,4 +1,4 @@
 target.origin.id=http://localhost:8080/pic-sure-api-2/PICSURE/
 visualization.resource.id=ca0ad4a9-130a-3a8a-ae00-e35b07f1108b
 open.hpds.resource.id=70c837be-5ffc-11eb-ae93-0242ac130002
-auth.hpds.resource.id=${auth_hpds_resource_id}
+auth.hpds.resource.id=02e23f52-f354-4e8b-992c-d37c8b9ba140

--- a/app-infrastructure/db/picsure/V2__Insert_Resources.sql
+++ b/app-infrastructure/db/picsure/V2__Insert_Resources.sql
@@ -2,28 +2,20 @@
 INSERT INTO `resource`
 VALUES (0xCA0AD4A9130A3A8AAE00E35B07F1108B, NULL,
         'http://localhost:8080/pic-sure-visualization-resource/pic-sure/visualization', 'Visualization',
-        'visualization', NULL, NULL, NULL);
+        'visualization', NULL, false, NULL);
 INSERT INTO `resource`
 VALUES (0x70c837be5ffc11ebae930242ac130002, NULL,
         'http://localhost:8080/pic-sure-aggregate-resource/pic-sure/aggregate-data-sharing',
-        'Open Access (aggregate) resource', 'open-hpds', NULL, NULL, NULL);
+        'Open Access (aggregate) resource', 'open-hpds', NULL, ${include_open_hpds}, NULL);
 
 -- For both Auth HPDS and the Dictionary, we need to include the target_stack and env_private_dns_name variables in the URL.
 -- This requires two separate resources for each, one for the Auth HPDS and one for the Dictionary.
 INSERT INTO `resource`
 VALUES (unhex(REPLACE('02e23f52-f354-4e8b-992c-d37c8b9ba140', '-', '')), NULL,
-        'http://auth-hpds.a.${env_private_dns_name}:8080/PIC-SURE/', 'Authorized Access HPDS resource', 'auth-hpds',
-        NULL, NULL, NULL);
-INSERT INTO `resource`
-VALUES (unhex(REPLACE('9e765d93-49a9-42a5-884b-412a6a44af81', '-', '')), NULL,
-        'http://auth-hpds.b.${env_private_dns_name}:8080/PIC-SURE/', 'Authorized Access HPDS resource', 'auth-hpds',
-        NULL, NULL, NULL);
+        'http://auth-hpds.___target_stack___:8080/PIC-SURE/', 'Authorized Access HPDS resource', 'auth-hpds',
+        NULL, ${include_auth_hpds}, NULL);
 
 INSERT INTO `resource`
-VALUES (unhex(REPLACE('4c6e53d0-0860-4129-9bbd-568b18833f98', '-', '')), NULL,
-        'http://dictionary.a.${env_private_dns_name}:8080/dictionary/pic-sure', 'Dictionary', 'dictionary', NULL, NULL,
-        NULL);
-INSERT INTO `resource`
 VALUES (unhex(REPLACE('36363664-6231-6134-2d38-6538652d3131', '-', '')), NULL,
-        'http://dictionary.b.${env_private_dns_name}:8080/dictionary/pic-sure', 'Dictionary', 'dictionary', NULL, NULL,
+        'http://dictionary.___target_stack___:8080/dictionary/pic-sure', 'Dictionary', 'dictionary', NULL, false,
         NULL);

--- a/app-infrastructure/httpd-instance.tf
+++ b/app-infrastructure/httpd-instance.tf
@@ -92,8 +92,6 @@ data "template_file" "picsureui_settings" {
     login_link                    = var.login_link
     client_id                     = var.client_id
     pdf_link                      = var.pdf_link
-    auth_hpds_resource_id         = var.auth_hpds_resource_id
-    dictionary_resource_id        = var.dictionary_resource_id
   }
 }
 

--- a/app-infrastructure/scripts/wildfly-user_data.sh
+++ b/app-infrastructure/scripts/wildfly-user_data.sh
@@ -40,7 +40,7 @@ s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/
 s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/visualization-resource.properties /home/centos/visualization-resource.properties
 
 WILDFLY_IMAGE=`sudo docker load < /home/centos/pic-sure-wildfly.tar.gz | cut -d ' ' -f 3`
-JAVA_OPTS="-Xms2g -Xmx26g -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=1024m -Djava.net.preferIPv4Stack=true"
+JAVA_OPTS="-Xms2g -Xmx26g -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=1024m -Djava.net.preferIPv4Stack=true -DTARGET_STACK=${target_stack}.${env_private_dns_name}"
 
 sudo mkdir /var/log/{wildfly-docker-logs,wildfly-docker-os-logs}
 

--- a/app-infrastructure/variables.tf
+++ b/app-infrastructure/variables.tf
@@ -195,16 +195,6 @@ variable "picsure_db_username" {
     description = "The username for the picsure db"
 }
 
-variable "auth_hpds_resource_id" {
-    type = string
-    description = "The resource id for the auth hpds"
-}
-
-variable "dictionary_resource_id" {
-    type = string
-    description = "The resource id for the dictionary"
-}
-
 variable "referer_allowed_domains" {
     type = string
     description = "The referer allowed domains. A regex string to match the referer domain"

--- a/app-infrastructure/wildfly-instance.tf
+++ b/app-infrastructure/wildfly-instance.tf
@@ -101,7 +101,6 @@ data "template_file" "visualization-resource-properties" {
   template = file("configs/visualization-resource.properties")
   vars     = {
     target_stack                      = var.target_stack
-    auth_hpds_resource_id             = var.auth_hpds_resource_id
   }
 }
 

--- a/app-infrastructure/wildfly-instance.tf
+++ b/app-infrastructure/wildfly-instance.tf
@@ -6,6 +6,7 @@ data "template_file" "wildfly-user_data" {
     dataset_s3_object_key   = var.dataset_s3_object_key
     target_stack            = var.target_stack
     gss_prefix              = "${var.environment_prefix}_${var.env_is_open_access ? "open" : "auth"}_${var.environment_name}"
+    env_private_dns_name    = var.env_private_dns_name
   }
 }
 


### PR DESCRIPTION
The `auth_hpds_resource_id` and `dictionary_resource_id` variables in application configurations have been removed and replaced with hardcoded values. This change affected several files including `wildfly-instance.tf` and `picsureui_settings.json`. This modification simplifies configuration and minimizes the risk of misconfiguration errors.