### PR TITLE
[ALS-6087] Update IDP provider URI value in standalone.xml

### DIFF
--- a/app-infrastructure/configs/standalone.xml
+++ b/app-infrastructure/configs/standalone.xml
@@ -517,7 +517,7 @@
 
                 <!-- Configure Identity Provider Parameters, with defaults-->
                 <simple name="java:global/idp_provider" value="${idp_provider}"/>
-                <simple name="java:global/idp_provider_uri" value="${idp_provider_uri}/"/>
+                <simple name="java:global/idp_provider_uri" value="${idp_provider_uri}"/>
 
                 <!-- Configure Fence Parameters, with defaults-->
                 <simple name="java:global/fence_client_id" value="${fence_client_id}"/>


### PR DESCRIPTION
Remove additional "/" all strings that are appended to the idp_provider_uri start with a "/".

Additionally, I have removed the additional `/` at the end of the idp_provider Jenkins global parameter for Authorized Jenkins Dev. This change will need to be made in Production before the next release.