### PR TITLE
[ALS-6198] Convert picsure resource id to a variable

### DIFF
--- a/app-infrastructure/configs/picsureui_settings.json
+++ b/app-infrastructure/configs/picsureui_settings.json
@@ -8,7 +8,7 @@
     }
   ],
   "queryExportType": "EXPORT_ASYNC",
-  "picSureResourceId": "02e23f52-f354-4e8b-992c-d37c8b9ba140",
+  "picSureResourceId": "${pic_sure_resource_id}",
   "openAccessResourceId": "70c837be-5ffc-11eb-ae93-0242ac130002",
   "visualizationResourceId": "ca0ad4a9-130a-3a8a-ae00-e35b07f1108b",
   "dictionaryResourceId": "36363664-6231-6134-2d38-6538652d3131",

--- a/app-infrastructure/httpd-instance.tf
+++ b/app-infrastructure/httpd-instance.tf
@@ -92,6 +92,7 @@ data "template_file" "picsureui_settings" {
     login_link                    = var.login_link
     client_id                     = var.client_id
     pdf_link                      = var.pdf_link
+    pic_sure_resource_id          = var.pic_sure_resource_id
   }
 }
 

--- a/app-infrastructure/variables.tf
+++ b/app-infrastructure/variables.tf
@@ -199,3 +199,8 @@ variable "referer_allowed_domains" {
     type = string
     description = "The referer allowed domains. A regex string to match the referer domain"
 }
+
+variable "pic_sure_resource_id" {
+    type = string
+    description = "The resource id for the pic-sure. Used for auth or open HPDS generally"
+}

--- a/app-infrastructure/wildfly-instance.tf
+++ b/app-infrastructure/wildfly-instance.tf
@@ -23,7 +23,7 @@ data "template_cloudinit_config" "wildfly-user-data" {
 
 resource "aws_instance" "wildfly-ec2" {
   ami           = local.ami_id
-  instance_type = "m5.large"
+  instance_type = "m5.2xlarge"
 
   subnet_id = local.private2_subnet_ids[0]
 


### PR DESCRIPTION
Some request are being sent to the API with the auth-hpds UUID. This is likely a result of this UUID being used in some request. We need to ensure open or auth queries the appropriate HPDS type.