### PR TITLE
[ALS-6396] Add XSS protection to httpd-vhosts config

### DIFF
--- a/app-infrastructure/configs/httpd-vhosts.conf
+++ b/app-infrastructure/configs/httpd-vhosts.conf
@@ -71,9 +71,12 @@ ServerTokens Prod
 
     # Enables built-in XSS protection in modern web browsers.
     # If a XSS is detected mode=block will block the entire page.
-
     # A fall back for legacy browsers that don't yet support CSP frame-ancestors.
     Header always set X-Frame-Options "DENY"
+
+    # Enables built-in XSS protection in modern web browsers.
+    # If a XSS is detected mode=block will block the entire page.
+    Header always set X-XSS-Protection "1; mode=block;"
 
     RewriteEngine On
     ProxyPreserveHost On


### PR DESCRIPTION
The httpd-vhosts configuration has been updated to include Cross-Site Scripting (XSS) protection. This change uses the built-in XSS protection available in modern web browsers. If an XSS attack is detected, the browser will block the entire page.