### PR TITLE
[ALS-6398] BDC Auth: Cookie Does Not Contain The "HTTPOnly" Attribute

### DIFF
--- a/app-infrastructure/configs/standalone.xml
+++ b/app-infrastructure/configs/standalone.xml
@@ -596,7 +596,7 @@
                 </host>
             </server>
             <servlet-container name="default">
-                <session-cookie http-only="true" secure="true"/>
+                <session-cookie name="JSESSIONID" path="/" http-only="true" secure="true"/>
                 <jsp-config/>
             </servlet-container>
             <filters>


### PR DESCRIPTION
[ALS-6398] BDC Auth: Cookie Does Not Contain The "HTTPOnly" Attribute