### PR TITLE
[ALS-7051] Deploy Data Dictionary API (#152)

### DIFF
--- a/app-infrastructure/db/auth/v7__Dictionary_Auth_Access_Rule.sql
+++ b/app-infrastructure/db/auth/v7__Dictionary_Auth_Access_Rule.sql
@@ -1,0 +1,20 @@
+# Simple rule to allow routing to the dictionary
+use auth;
+
+SET @allowDictionaryRequests = unhex(REPLACE(UUID(),'-',''));
+-- Access rule for allowing requests to the uploader via proxy
+INSERT
+INTO access_rule (
+    uuid, name, description, rule, type, value, checkMapKeyOnly, checkMapNode,
+    subAccessRuleParent_uuid, isGateAnyRelation, isEvaluateOnlyByGates
+)    VALUES (
+                @allowDictionaryRequests, 'ALLOW_DICTIONARY_REQUESTS', 'Permit requests to dictionary endpoints',
+                '$.[\'Target Service\']', 11, '^/proxy/dictionary-api.*$',
+             0x00, 0x00, NULL, 0x00, 0x00
+            );
+-- Add that access rule to the PIC_SURE_ANY_QUERY privilege
+SET @uuidPriv = (SELECT uuid FROM privilege WHERE name = 'MANAGED_PRIV_DICTIONARY'); -- FENCE_ was previously replaced with MANAGED_
+INSERT
+INTO accessRule_privilege (privilege_id, accessRule_id)
+VALUES
+    (@uuidPriv, @allowDictionaryRequests);

--- a/app-infrastructure/db/picsure/V3__Create_Dictionary_resource.sql
+++ b/app-infrastructure/db/picsure/V3__Create_Dictionary_resource.sql
@@ -1,0 +1,9 @@
+use picsure;
+
+SET @dictResourceUUID = unhex(REPLACE(UUID(), '-', ''));
+
+INSERT INTO `resource`
+(uuid, targetURL, resourceRSPath, description, name, token, hidden, metadata)
+VALUES
+    (@dictResourceUUID, NULL, 'http://dictionary-api/',
+     'Dictionary API', 'dictionary-api', NULL, TRUE, NULL);

--- a/app-infrastructure/scripts/dictionary-docker.sh
+++ b/app-infrastructure/scripts/dictionary-docker.sh
@@ -8,34 +8,17 @@ s3_copy() {
 }
 
 ## pull configs and images from s3
-s3_copy "s3://${stack_s3_bucket}/configs/dictionary/weights.csv" "/home/centos/weights.csv"
 s3_copy "s3://${stack_s3_bucket}/containers/application/dictionary-api.tar.gz" "/home/centos/dictionary-api.tar.gz"
-s3_copy "s3://${stack_s3_bucket}/containers/application/dictionary-weights.tar.gz" "/home/centos/dictionary-weights.tar.gz"
 
 # load docker images
 DICTIONARY_API_IMAGE=`sudo docker load < /home/centos/dictionary-api.tar.gz | cut -d ' ' -f 3`
-DICTIONARY_WEIGHTS_IMAGE=`sudo docker load < /home/centos/dictionary-weights.tar.gz | cut -d ' ' -f 3`
 
-# a blank env files.  db connections will need to use secrets manager
-touch .env
-
-# run containers
-# Going to try the picsure network....
-
+sudo docker stop dictionary-api
+sudo docker rm dictionary-api
 sudo docker run \
       --name dictionary-api \
       --restart always \
-      --env-file=.env \
       --network picsure \
       --log-driver syslog --log-opt tag=dictionary-api \
       --restart always \
       -d $DICTIONARY_API_IMAGE
-
-sudo docker run \
-      --restart always \
-      --name dictionary-weights \
-      --env-file=.env \
-      --network picsure \
-      --log-driver syslog --log-opt tag=dictionary-weights \
-      -v /home/centos/weights.csv:/weights.csv \
-      -d $DICTIONARY_WEIGHTS_IMAGE

--- a/app-infrastructure/variables.tf
+++ b/app-infrastructure/variables.tf
@@ -190,3 +190,8 @@ variable "app_user_secret_name" {
     type = string
     description = "The secret name for the application user"
 }
+
+variable "app_psql_user_secret_name" {
+    type = string
+    description = "The secret name for the application psql user"
+}

--- a/app-infrastructure/wildfly-iam.tf
+++ b/app-infrastructure/wildfly-iam.tf
@@ -31,15 +31,18 @@ resource "aws_iam_role_policy" "wildfly-deployment-sm-policy" {
 {
   "Version": "2012-10-17",
   "Statement": [
-      {
+    {
       "Action": [
-          "secretsmanager:GetSecretValue",
-          "secretsmanager:DescribeSecret"
+        "secretsmanager:GetSecretValue",
+        "secretsmanager:DescribeSecret"
       ],
       "Effect": "Allow",
-      "Resource": "arn:aws:secretsmanager:${data.aws_region.current.name}:${var.app_acct_id}:secret:${var.app_user_secret_name}-*"
-      }
-    ]
+      "Resource": [
+        "arn:aws:secretsmanager:${data.aws_region.current.name}:${var.app_acct_id}:secret:${var.app_user_secret_name}-*",
+        "arn:aws:secretsmanager:${data.aws_region.current.name}:${var.app_acct_id}:secret:${var.app_psql_user_secret_name}-*"
+      ]
+    }
+  ]
 }
 EOF
 }


### PR DESCRIPTION
* Update HTTPD ec2 user script for new UI

* Reroute to localhost

* Update httpd-vhosts.conf

* deprecated dictionary resource
* dictionary will be run on the wildfly instance

* user-script and container run script

* iam updates

* removing dictionary resources from outputs and route 53

* Update wildfly-iam.tf

* add containers/application condition

* fixing up container run

# Both containers should start up now
* api looks to be running and staying up
* the weights container is in a restart loop due to not being able to connect to the db which is expected

* New UI - updates (#150)

* Update zip name

* Update tar name

* Fix routing

---------



* Remove dictionary weights image and container

Eliminated the loading and running of the dictionary weights Docker image and container alongside the related S3 copy command. This simplifies the deployment script by focusing solely on the dictionary API. We will deploy the weights service on Jenkins as it is a temporary container.

* Create dictionary resource and authorization rules

Added SQL scripts to create a dictionary resource and an access rule for it. The dictionary resource is defined with specific endpoint details, while the corresponding access rule allows routing requests to this resource. This setup is essential for enabling API interactions and ensuring proper access control.

* Remove unnecessary .env file and comments from script

Removed the creation of a blank .env file and redundant comments in the `dictionary-docker.sh` script. Removed an unnecessary S3 copy command for weights.csv and ensured the Docker container is properly restarted by stopping and removing the existing one before running a new instance.

* Add IAM permissions for new PostgreSQL secret

Extended IAM policy to include permissions for accessing the PostgreSQL user secret. Introduced a new variable for the PostgreSQL secret name in the variables file.

* Fix incorrect parameter in dictionary resource SQL script

Changed 'dictResourceUUID' to '@dictResourceUUID' in the SQL insert statement to properly reference the variable. This ensures the dictionary resource is created with the correct UUID parameter.

---------