### PR TITLE
[ALS-7751] Increase resources for BDC

### DIFF
--- a/app-infrastructure/auth-hpds-instance.tf
+++ b/app-infrastructure/auth-hpds-instance.tf
@@ -26,7 +26,7 @@ resource "aws_instance" "auth-hpds-ec2" {
   count = var.include_auth_hpds ? 1 : 0
 
   ami           = local.ami_id
-  instance_type = "m5.12xlarge"
+  instance_type = "m5.24xlarge"
 
   subnet_id = local.private2_subnet_ids[0]
 

--- a/app-infrastructure/open-hpds-instance.tf
+++ b/app-infrastructure/open-hpds-instance.tf
@@ -25,7 +25,7 @@ resource "aws_instance" "open-hpds-ec2" {
   count = var.include_open_hpds ? 1 : 0
 
   ami           = local.ami_id
-  instance_type = "m5.2xlarge"
+  instance_type = "m5.4xlarge"
 
   subnet_id = local.private2_subnet_ids[0]
 

--- a/app-infrastructure/scripts/auth_hpds-user_data.sh
+++ b/app-infrastructure/scripts/auth_hpds-user_data.sh
@@ -47,7 +47,7 @@ sudo docker run --name=$CONTAINER_NAME \
                 --log-driver syslog --log-opt tag=auth-hpds \
                 -v /opt/local/hpds:/opt/local/hpds \
                 -p 8080:8080 \
-                -e JAVA_OPTS=" -XX:+UseParallelGC -XX:SurvivorRatio=250 -Xms10g -Xmx128g -Dserver.port=8080 -Dspring.profiles.active=bdc-auth -DCACHE_SIZE=2500 -DID_BATCH_SIZE=5000 -DALL_IDS_CONCEPT=NONE -DID_CUBE_NAME=NONE "  \
+                -e JAVA_OPTS=" -XX:+UseParallelGC -XX:SurvivorRatio=250 -Xms10g -Xmx360g -Dserver.port=8080 -Dspring.profiles.active=bdc-auth -DCACHE_SIZE=2500 -DID_BATCH_SIZE=5000 -DALL_IDS_CONCEPT=NONE -DID_CUBE_NAME=NONE "  \
                 -d $HPDS_IMAGE
 
 echo "Waiting for container to initialize"

--- a/app-infrastructure/scripts/dictionary-docker.sh
+++ b/app-infrastructure/scripts/dictionary-docker.sh
@@ -13,10 +13,12 @@ s3_copy "s3://${stack_s3_bucket}/containers/application/dictionary-api.tar.gz" "
 
 # load docker images
 DICTIONARY_API_IMAGE=`sudo docker load < /home/centos/dictionary-api.tar.gz | cut -d ' ' -f 3`
+JAVA_OPTS="-Xmx16g"
 
 sudo docker stop dictionary-api
 sudo docker rm dictionary-api
 sudo docker run \
+      -e $JAVA_OPTS \
       --env-file /home/centos/picsure-dictionary.env \
       --name dictionary-api \
       --restart always \

--- a/app-infrastructure/scripts/dictionary-docker.sh
+++ b/app-infrastructure/scripts/dictionary-docker.sh
@@ -13,7 +13,7 @@ s3_copy "s3://${stack_s3_bucket}/containers/application/dictionary-api.tar.gz" "
 
 # load docker images
 DICTIONARY_API_IMAGE=`sudo docker load < /home/centos/dictionary-api.tar.gz | cut -d ' ' -f 3`
-JAVA_OPTS=" -Xmx16g -XX:+PrintFlagsFinal "
+JAVA_OPTS=" -Xmx24g "
 
 sudo docker stop dictionary-api
 sudo docker rm dictionary-api

--- a/app-infrastructure/scripts/dictionary-docker.sh
+++ b/app-infrastructure/scripts/dictionary-docker.sh
@@ -13,7 +13,7 @@ s3_copy "s3://${stack_s3_bucket}/containers/application/dictionary-api.tar.gz" "
 
 # load docker images
 DICTIONARY_API_IMAGE=`sudo docker load < /home/centos/dictionary-api.tar.gz | cut -d ' ' -f 3`
-JAVA_OPTS="-Xmx16g"
+JAVA_OPTS=" -Xmx16g -XX:+PrintFlagsFinal "
 
 sudo docker stop dictionary-api
 sudo docker rm dictionary-api

--- a/app-infrastructure/scripts/dictionary-docker.sh
+++ b/app-infrastructure/scripts/dictionary-docker.sh
@@ -18,7 +18,7 @@ JAVA_OPTS=" -Xmx24g "
 sudo docker stop dictionary-api
 sudo docker rm dictionary-api
 sudo docker run \
-      -e $JAVA_OPTS \
+      -e JAVA_OPTS="$JAVA_OPTS" \
       --env-file /home/centos/picsure-dictionary.env \
       --name dictionary-api \
       --restart always \

--- a/app-infrastructure/scripts/open_hpds-user_data.sh
+++ b/app-infrastructure/scripts/open_hpds-user_data.sh
@@ -43,7 +43,7 @@ sudo docker run --name=$CONTAINER_NAME \
                 --log-driver syslog --log-opt tag=open-hpds \
                 -v /opt/local/hpds:/opt/local/hpds \
                 -p 8080:8080 \
-                -e JAVA_OPTS=" -XX:+UseParallelGC -XX:SurvivorRatio=250 -Xms10g -Xmx40g -Dserver.port=8080 -Dspring.profiles.active=open -DCACHE_SIZE=2500 -DSMALL_TASK_THREADS=1 -DLARGE_TASK_THREADS=1 -DSMALL_JOB_LIMIT=100 -DID_BATCH_SIZE=5000 " \
+                -e JAVA_OPTS=" -XX:+UseParallelGC -XX:SurvivorRatio=250 -Xms10g -Xmx60g -Dserver.port=8080 -Dspring.profiles.active=open -DCACHE_SIZE=2500 -DSMALL_TASK_THREADS=1 -DLARGE_TASK_THREADS=1 -DSMALL_JOB_LIMIT=100 -DID_BATCH_SIZE=5000 " \
                 -d $HPDS_IMAGE
 
 echo "Waiting for container to initialize"

--- a/app-infrastructure/scripts/psama-docker.sh
+++ b/app-infrastructure/scripts/psama-docker.sh
@@ -15,7 +15,7 @@ s3_copy "s3://${stack_s3_bucket}/releases/psama/psama.tar.gz" "/home/centos/psam
 
 # This script is responsible for starting or updating the psama container
 PSAMA_IMAGE=$(sudo docker load < /home/centos/psama.tar.gz | cut -d ' ' -f 3)
-PSAMA_OPTS="-Xms1g -Xmx2g -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=512m -Djava.net.preferIPv4Stack=true"
+PSAMA_OPTS="-Xms2g -Xmx8g -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=512m -Djava.net.preferIPv4Stack=true"
 
 # Add remote debugging options if enabled.
 # To enable remote debugging, set the second script argument to true.

--- a/app-infrastructure/scripts/wildfly-user_data.sh
+++ b/app-infrastructure/scripts/wildfly-user_data.sh
@@ -41,6 +41,12 @@ s3_copy() {
 echo "waiting for terraform to render files"
 sleep 300
 
+# Add swap space
+sudo dd if=/dev/zero of=/swapfile count=15360 bs=1MiB
+sudo chmod 600 /swapfile
+sudo mkswap /swapfile
+sudo swapon /swapfile
+
 # make picsure network
 sudo docker network create picsure
 sudo mkdir /var/log/{wildfly-docker-logs,wildfly-docker-os-logs,psama-docker-logs,psama-docker-os-logs}

--- a/app-infrastructure/wildfly-instance.tf
+++ b/app-infrastructure/wildfly-instance.tf
@@ -23,7 +23,7 @@ data "template_cloudinit_config" "wildfly-user-data" {
 
 resource "aws_instance" "wildfly-ec2" {
   ami           = local.ami_id
-  instance_type = "m5.2xlarge"
+  instance_type = "m5.4xlarge"
 
   subnet_id = local.private2_subnet_ids[0]
 


### PR DESCRIPTION
## Temporarily increase resources for BDC
- Auth HPDS has been increased to a `m5.24xlarge`
>- Has been updated to use `Xmx360g`
- Open HPDS has been increased to a `m5.4xlarge`
>- Has been updated to use `Xmx60g`
- WildFly EC2 has been increased to an `m5.4xlarge`
- Dictionary API now passes Java Opts to container
>- Has been increased to `Xmx24g`
- PSAMA now has been set to use `Xmx8g` 

## Swap Space
WildFly user script now creates swap space equal to half the size of available instance memory.