### PR TITLE
Migrate legacy dictionary to new Dictionary-API

### DIFF
--- a/app-infrastructure/db/picsure/V4__Migrate_Legacy_Dictionary_Search.sql
+++ b/app-infrastructure/db/picsure/V4__Migrate_Legacy_Dictionary_Search.sql
@@ -1,0 +1,3 @@
+-- Point the legacy dictionary UUID to the new Dictionary-API
+-- Eventually we will complete remove this resource from the dictionary.
+update resource SET resourceRSPath = 'http://dictionary-api/' WHERE UUID = unhex(replace('36363664-6231-6134-2d38-6538652d3131', '-', ''));


### PR DESCRIPTION
- As an intermediate step in phasing out the legacy **search-prototype** from our application, we are redirecting all search traffic to the new **dictionary-api**.