### PR TITLE
Update passport column type to MEDIUMTEXT

### DIFF
--- a/app-infrastructure/db/auth/V12__Modify_Passport_Column_Type.sql
+++ b/app-infrastructure/db/auth/V12__Modify_Passport_Column_Type.sql
@@ -1,0 +1,1 @@
+alter table user modify passport MEDIUMTEXT null;


### PR DESCRIPTION
Change the `passport` column in the `user` table to `MEDIUMTEXT` to allow for longer values.