### PR TITLE
Refactor logging configurations and clean up Splunk inputs

### DIFF
--- a/app-infrastructure/scripts/auth_hpds-user_data.sh
+++ b/app-infrastructure/scripts/auth_hpds-user_data.sh
@@ -17,7 +17,7 @@ s3_copy() {
 }
 
 mkdir -p /opt/local/hpds/all
-mkdir -p /var/log/auth-hpds/
+sudo mkdir -p /var/log/auth-hpds/
 
 s3_copy s3://${stack_s3_bucket}/releases/jenkins_pipeline_build_${stack_githash}/pic-sure-hpds.tar.gz /home/centos/pic-sure-hpds.tar.gz
 s3_copy s3://${stack_s3_bucket}/data/${dataset_s3_object_key}/javabins_rekeyed.tar /opt/local/hpds/javabins_rekeyed.tar

--- a/app-infrastructure/scripts/auth_hpds-user_data.sh
+++ b/app-infrastructure/scripts/auth_hpds-user_data.sh
@@ -4,10 +4,6 @@ echo "SPLUNK_INDEX=hms_aws_${gss_prefix}" | sudo tee /opt/srce/startup.config
 echo "NESSUS_GROUP=${gss_prefix}_${target_stack}" | sudo tee -a /opt/srce/startup.config
 
 sudo sh /opt/srce/scripts/start-gsstools.sh
-sudo systemctl stop SplunkForwarder
-
-/opt/splunkforwarder/bin/splunk enable boot-start -systemd-managed 1 -user splunk || true
-
 echo "user-data progress starting update"
 
 s3_copy() {
@@ -17,7 +13,7 @@ s3_copy() {
 }
 
 mkdir -p /opt/local/hpds/all
-sudo mkdir -p /var/log/auth-hpds/
+sudo mkdir -p /var/log/picsure/auth-hpds/
 
 s3_copy s3://${stack_s3_bucket}/releases/jenkins_pipeline_build_${stack_githash}/pic-sure-hpds.tar.gz /home/centos/pic-sure-hpds.tar.gz
 s3_copy s3://${stack_s3_bucket}/data/${dataset_s3_object_key}/javabins_rekeyed.tar /opt/local/hpds/javabins_rekeyed.tar
@@ -38,7 +34,7 @@ CONTAINER_NAME="auth-hpds"
 HPDS_IMAGE=`sudo docker load < /home/centos/pic-sure-hpds.tar.gz | cut -d ' ' -f 3`
 sudo docker run --name=$CONTAINER_NAME \
                 --restart unless-stopped \
-                -v /var/log/auth-hpds/:/var/log/ \
+                -v /var/log/picsure/auth-hpds/:/var/log/ \
                 --log-opt tag=auth-hpds \
                 -v /opt/local/hpds:/opt/local/hpds \
                 -p 8080:8080 \
@@ -69,8 +65,5 @@ while true; do
   fi
 done
 
-
-echo "Restart splunkforwarder service"
-sudo systemctl restart SplunkForwarder
 echo "user-data progress starting update"
 sudo yum -y update

--- a/app-infrastructure/scripts/auth_hpds-user_data.sh
+++ b/app-infrastructure/scripts/auth_hpds-user_data.sh
@@ -4,14 +4,6 @@ echo "SPLUNK_INDEX=hms_aws_${gss_prefix}" | sudo tee /opt/srce/startup.config
 echo "NESSUS_GROUP=${gss_prefix}_${target_stack}" | sudo tee -a /opt/srce/startup.config
 
 sudo sh /opt/srce/scripts/start-gsstools.sh
-
-echo "
-[monitor:///var/log/hpds-docker-logs]
-sourcetype = hms_app_logs
-source = hpds_logs
-index=hms_aws_${gss_prefix}
-" | sudo tee -a /opt/splunkforwarder/etc/system/local/inputs.conf
-
 sudo systemctl stop SplunkForwarder
 
 /opt/splunkforwarder/bin/splunk enable boot-start -systemd-managed 1 -user splunk || true
@@ -44,7 +36,8 @@ CONTAINER_NAME="auth-hpds"
 HPDS_IMAGE=`sudo docker load < /home/centos/pic-sure-hpds.tar.gz | cut -d ' ' -f 3`
 sudo docker run --name=$CONTAINER_NAME \
                 --restart unless-stopped \
-                --log-driver syslog --log-opt tag=auth-hpds \
+                -v /var/log/auth-hpds/:/var/log/ \
+                --log-opt tag=auth-hpds \
                 -v /opt/local/hpds:/opt/local/hpds \
                 -p 8080:8080 \
                 -e JAVA_OPTS=" -XX:+UseParallelGC -XX:SurvivorRatio=250 -Xms10g -Xmx128g -Dserver.port=8080 -Dspring.profiles.active=bdc-auth-${environment_name} -DTARGET_STACK=${target_stack}.${env_private_dns_name} -DCACHE_SIZE=2500 -DID_BATCH_SIZE=5000 -DALL_IDS_CONCEPT=NONE -DID_CUBE_NAME=NONE "  \

--- a/app-infrastructure/scripts/auth_hpds-user_data.sh
+++ b/app-infrastructure/scripts/auth_hpds-user_data.sh
@@ -17,6 +17,8 @@ s3_copy() {
 }
 
 mkdir -p /opt/local/hpds/all
+mkdir -p /var/log/auth-hpds/
+
 s3_copy s3://${stack_s3_bucket}/releases/jenkins_pipeline_build_${stack_githash}/pic-sure-hpds.tar.gz /home/centos/pic-sure-hpds.tar.gz
 s3_copy s3://${stack_s3_bucket}/data/${dataset_s3_object_key}/javabins_rekeyed.tar /opt/local/hpds/javabins_rekeyed.tar
 s3_copy s3://${stack_s3_bucket}/data/${genomic_dataset_s3_object_key}/all/ /opt/local/hpds/all/ --recursive

--- a/app-infrastructure/scripts/dictionary-docker.sh
+++ b/app-infrastructure/scripts/dictionary-docker.sh
@@ -18,7 +18,7 @@ JAVA_OPTS=" -Xmx8g "
 sudo docker stop dictionary-api
 sudo docker rm dictionary-api
 sudo docker run \
-      -v /var/log/dictionary/:/var/log/ \
+      -v /var/log/picsure/dictionary/:/var/log/ \
       --log-opt tag=dictionary-api \
       -e JAVA_OPTS="$JAVA_OPTS" \
       --env-file /home/centos/picsure-dictionary.env \

--- a/app-infrastructure/scripts/dictionary-docker.sh
+++ b/app-infrastructure/scripts/dictionary-docker.sh
@@ -18,11 +18,12 @@ JAVA_OPTS=" -Xmx8g "
 sudo docker stop dictionary-api
 sudo docker rm dictionary-api
 sudo docker run \
+      -v /var/log/dictionary/:/var/log/ \
+      --log-opt tag=dictionary-api \
       -e JAVA_OPTS="$JAVA_OPTS" \
       --env-file /home/centos/picsure-dictionary.env \
       --name dictionary-api \
       --restart always \
       --network picsure \
-      --log-driver syslog --log-opt tag=dictionary-api \
       --restart always \
       -d $DICTIONARY_API_IMAGE

--- a/app-infrastructure/scripts/httpd-docker.sh
+++ b/app-infrastructure/scripts/httpd-docker.sh
@@ -18,8 +18,8 @@ sudo docker system prune -a -f || true
 HTTPD_IMAGE=`sudo docker load < /home/centos/pic-sure-frontend.tar.gz | cut -d ' ' -f 3`
 sudo docker run --name=httpd \
 --restart unless-stopped \
---log-driver syslog --log-opt tag=httpd \
--v /var/log/httpd-docker-logs/:/usr/local/apache2/logs/ \
+--log-opt tag=httpd \
+-v /var/log/httpd/:/usr/local/apache2/logs/ \
 -v /home/centos/fence_mapping.json:/usr/local/apache2/htdocs/picsureui/studyAccess/studies-data.json \
 -v /usr/local/docker-config/cert:/usr/local/apache2/cert/ \
 -v /usr/local/docker-config/httpd-vhosts.conf:/usr/local/apache2/conf/extra/httpd-vhosts.conf \

--- a/app-infrastructure/scripts/httpd-docker.sh
+++ b/app-infrastructure/scripts/httpd-docker.sh
@@ -19,7 +19,7 @@ HTTPD_IMAGE=`sudo docker load < /home/centos/pic-sure-frontend.tar.gz | cut -d '
 sudo docker run --name=httpd \
 --restart unless-stopped \
 --log-opt tag=httpd \
--v /var/log/httpd/:/usr/local/apache2/logs/ \
+-v /var/log/picsure/httpd/:/usr/local/apache2/logs/ \
 -v /home/centos/fence_mapping.json:/usr/local/apache2/htdocs/picsureui/studyAccess/studies-data.json \
 -v /usr/local/docker-config/cert:/usr/local/apache2/cert/ \
 -v /usr/local/docker-config/httpd-vhosts.conf:/usr/local/apache2/conf/extra/httpd-vhosts.conf \

--- a/app-infrastructure/scripts/httpd-user_data.sh
+++ b/app-infrastructure/scripts/httpd-user_data.sh
@@ -8,8 +8,8 @@ sudo systemctl stop SplunkForwarder
 /opt/splunkforwarder/bin/splunk enable boot-start -systemd-managed 1 -user splunk || true
 
 mkdir -p /usr/local/docker-config/cert
-mkdir -p /var/log/httpd/
-mkdir -p /var/log/httpd-docker-logs/ssl_mutex
+sudo mkdir -p /var/log/httpd/
+sudo mkdir -p /var/log/httpd/ssl_mutex
 
 s3_copy() {
   for i in {1..5}; do

--- a/app-infrastructure/scripts/httpd-user_data.sh
+++ b/app-infrastructure/scripts/httpd-user_data.sh
@@ -8,6 +8,7 @@ sudo systemctl stop SplunkForwarder
 /opt/splunkforwarder/bin/splunk enable boot-start -systemd-managed 1 -user splunk || true
 
 mkdir -p /usr/local/docker-config/cert
+mkdir -p /var/log/httpd/
 mkdir -p /var/log/httpd-docker-logs/ssl_mutex
 
 s3_copy() {
@@ -25,8 +26,6 @@ s3_copy s3://${stack_s3_bucket}/data/${dataset_s3_object_key}/fence_mapping.json
 s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/httpd-docker.sh /home/centos/httpd-docker.sh
 
 for i in 1 2 3 4 5; do echo "confirming wildfly resolvable" && sudo curl --connect-timeout 1 $(grep -A30 preprod /usr/local/docker-config/httpd-vhosts.conf | grep wildfly | grep api | cut -d "\"" -f 2 | sed 's/pic-sure-api-2.*//') || if [ $? = 6 ]; then (exit 1); fi && break || sleep 60; done
-
-sudo mkdir -p /var/log/httpd-docker-logs
 
 sudo chmod +x /home/centos/httpd-docker.sh
 sudo /home/centos/httpd-docker.sh "${stack_s3_bucket}" "${stack_githash}"

--- a/app-infrastructure/scripts/httpd-user_data.sh
+++ b/app-infrastructure/scripts/httpd-user_data.sh
@@ -8,8 +8,8 @@ sudo systemctl stop SplunkForwarder
 /opt/splunkforwarder/bin/splunk enable boot-start -systemd-managed 1 -user splunk || true
 
 mkdir -p /usr/local/docker-config/cert
-sudo mkdir -p /var/log/httpd/
-sudo mkdir -p /var/log/httpd/ssl_mutex
+sudo mkdir -p /var/log/picsure/httpd/
+sudo mkdir -p /var/log/picsure/httpd/ssl_mutex
 
 s3_copy() {
   for i in {1..5}; do

--- a/app-infrastructure/scripts/httpd-user_data.sh
+++ b/app-infrastructure/scripts/httpd-user_data.sh
@@ -4,18 +4,8 @@ echo "SPLUNK_INDEX=hms_aws_${gss_prefix}" | sudo tee /opt/srce/startup.config
 echo "NESSUS_GROUP=${gss_prefix}_${target_stack}" | sudo tee -a /opt/srce/startup.config
 
 sudo sh /opt/srce/scripts/start-gsstools.sh
-
-echo "
-[monitor:///var/log/httpd-docker-logs/]
-sourcetype = hms_app_logs
-source = httpd_logs
-index=hms_aws_${gss_prefix}
-" | sudo tee -a /opt/splunkforwarder/etc/system/local/inputs.conf
-
 sudo systemctl stop SplunkForwarder
-
 /opt/splunkforwarder/bin/splunk enable boot-start -systemd-managed 1 -user splunk || true
-
 
 mkdir -p /usr/local/docker-config/cert
 mkdir -p /var/log/httpd-docker-logs/ssl_mutex

--- a/app-infrastructure/scripts/open_hpds-user_data.sh
+++ b/app-infrastructure/scripts/open_hpds-user_data.sh
@@ -4,14 +4,6 @@ echo "SPLUNK_INDEX=hms_aws_${gss_prefix}" | sudo tee /opt/srce/startup.config
 echo "NESSUS_GROUP=${gss_prefix}_${target_stack}" | sudo tee -a /opt/srce/startup.config
 
 sudo sh /opt/srce/scripts/start-gsstools.sh
-
-echo "
-[monitor:///var/log/hpds-docker-logs]
-sourcetype = hms_app_logs
-source = hpds_logs
-index=hms_aws_${gss_prefix}
-" | sudo tee -a /opt/splunkforwarder/etc/system/local/inputs.conf
-
 sudo systemctl stop SplunkForwarder
 
 /opt/splunkforwarder/bin/splunk enable boot-start -systemd-managed 1 -user splunk || true
@@ -40,7 +32,8 @@ CONTAINER_NAME="open-hpds"
 HPDS_IMAGE=`sudo docker load < /home/centos/pic-sure-hpds.tar.gz | cut -d ' ' -f 3`
 sudo docker run --name=$CONTAINER_NAME \
                 --restart unless-stopped \
-                --log-driver syslog --log-opt tag=open-hpds \
+                -v /var/log/open-hpds/:/var/log/ \
+                --log-opt tag=open-hpds \
                 -v /opt/local/hpds:/opt/local/hpds \
                 -p 8080:8080 \
                 -e JAVA_OPTS=" -XX:+UseParallelGC -XX:SurvivorRatio=250 -Xms10g -Xmx40g -Dserver.port=8080 -Dspring.profiles.active=open -DCACHE_SIZE=2500 -DSMALL_TASK_THREADS=1 -DLARGE_TASK_THREADS=1 -DSMALL_JOB_LIMIT=100 -DID_BATCH_SIZE=5000 " \

--- a/app-infrastructure/scripts/open_hpds-user_data.sh
+++ b/app-infrastructure/scripts/open_hpds-user_data.sh
@@ -4,9 +4,6 @@ echo "SPLUNK_INDEX=hms_aws_${gss_prefix}" | sudo tee /opt/srce/startup.config
 echo "NESSUS_GROUP=${gss_prefix}_${target_stack}" | sudo tee -a /opt/srce/startup.config
 
 sudo sh /opt/srce/scripts/start-gsstools.sh
-sudo systemctl stop SplunkForwarder
-
-/opt/splunkforwarder/bin/splunk enable boot-start -systemd-managed 1 -user splunk || true
 
 s3_copy() {
   for i in {1..5}; do
@@ -28,12 +25,12 @@ INIT_START_TIME=$(date +%s)
 
 CONTAINER_NAME="open-hpds"
 
-sudo mkdir -p /var/log/open-hpds/
+sudo mkdir -p /var/log/picsure/open-hpds/
 
 HPDS_IMAGE=`sudo docker load < /home/centos/pic-sure-hpds.tar.gz | cut -d ' ' -f 3`
 sudo docker run --name=$CONTAINER_NAME \
                 --restart unless-stopped \
-                -v /var/log/open-hpds/:/var/log/ \
+                -v /var/log/picsure/open-hpds/:/var/log/ \
                 --log-opt tag=open-hpds \
                 -v /opt/local/hpds:/opt/local/hpds \
                 -p 8080:8080 \
@@ -64,8 +61,5 @@ while true; do
   fi
 done
 
-
-echo "Restart splunkforwarder service"
-sudo systemctl restart SplunkForwarder
 echo "user-data progress starting update"
 sudo yum -y update

--- a/app-infrastructure/scripts/open_hpds-user_data.sh
+++ b/app-infrastructure/scripts/open_hpds-user_data.sh
@@ -15,7 +15,6 @@ s3_copy() {
 }
 
 s3_copy s3://${stack_s3_bucket}/releases/jenkins_pipeline_build_${stack_githash}/pic-sure-hpds.tar.gz /home/centos/pic-sure-hpds.tar.gz
-
 s3_copy s3://${stack_s3_bucket}/data/${destigmatized_dataset_s3_object_key}/destigmatized_javabins_rekeyed.tar /opt/local/hpds/destigmatized_javabins_rekeyed.tar
 
 cd /opt/local/hpds
@@ -28,6 +27,8 @@ INIT_TIMEOUT_SEX=2400  # Set your desired timeout in seconds
 INIT_START_TIME=$(date +%s)
 
 CONTAINER_NAME="open-hpds"
+
+mkdir -p /var/log/open-hpds/
 
 HPDS_IMAGE=`sudo docker load < /home/centos/pic-sure-hpds.tar.gz | cut -d ' ' -f 3`
 sudo docker run --name=$CONTAINER_NAME \

--- a/app-infrastructure/scripts/open_hpds-user_data.sh
+++ b/app-infrastructure/scripts/open_hpds-user_data.sh
@@ -28,7 +28,7 @@ INIT_START_TIME=$(date +%s)
 
 CONTAINER_NAME="open-hpds"
 
-mkdir -p /var/log/open-hpds/
+sudo mkdir -p /var/log/open-hpds/
 
 HPDS_IMAGE=`sudo docker load < /home/centos/pic-sure-hpds.tar.gz | cut -d ' ' -f 3`
 sudo docker run --name=$CONTAINER_NAME \

--- a/app-infrastructure/scripts/psama-docker.sh
+++ b/app-infrastructure/scripts/psama-docker.sh
@@ -35,10 +35,9 @@ sudo docker stop psama || true
 sudo docker rm psama || true
 sudo docker run -u root --name=psama --restart always --network=picsure \
 --env-file /home/centos/psama.env \
--v /var/log/psama-docker-os-logs/:/var/log/ \
--v /var/log/psama-docker-logs/:/opt/psama/logs/ \
+-v /var/log/psama/:/var/log/ \
 -e JAVA_OPTS="$PSAMA_OPTS" \
---log-driver syslog --log-opt tag=wildfly \
+--log-opt tag=psama \
 -v /home/centos/fence_mapping.json:/config/fence_mapping.json \
 $PSAMA_PORTS \
 -d $PSAMA_IMAGE

--- a/app-infrastructure/scripts/psama-docker.sh
+++ b/app-infrastructure/scripts/psama-docker.sh
@@ -35,7 +35,7 @@ sudo docker stop psama || true
 sudo docker rm psama || true
 sudo docker run -u root --name=psama --restart always --network=picsure \
 --env-file /home/centos/psama.env \
--v /var/log/psama/:/var/log/ \
+-v /var/log/picsure/picsure/psama/:/var/log/ \
 -e JAVA_OPTS="$PSAMA_OPTS" \
 --log-opt tag=psama \
 -v /home/centos/fence_mapping.json:/config/fence_mapping.json \

--- a/app-infrastructure/scripts/psama-docker.sh
+++ b/app-infrastructure/scripts/psama-docker.sh
@@ -35,7 +35,7 @@ sudo docker stop psama || true
 sudo docker rm psama || true
 sudo docker run -u root --name=psama --restart always --network=picsure \
 --env-file /home/centos/psama.env \
--v /var/log/picsure/picsure/psama/:/var/log/ \
+-v /var/log/picsure/psama/:/var/log/ \
 -e JAVA_OPTS="$PSAMA_OPTS" \
 --log-opt tag=psama \
 -v /home/centos/fence_mapping.json:/config/fence_mapping.json \

--- a/app-infrastructure/scripts/wildfly-docker.sh
+++ b/app-infrastructure/scripts/wildfly-docker.sh
@@ -25,11 +25,10 @@ JAVA_OPTS="-Xms2g -Xmx24g -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=1024m -Djav
 
 sudo docker run -u root --name=wildfly --network=picsure \
                         --restart unless-stopped \
-                        --log-driver syslog --log-opt tag=wildfly \
-                        -v /var/log/wildfly-docker-logs/:/opt/jboss/wildfly/standalone/log/ \
+                        --log-opt tag=wildfly \
+                        -v /var/log/wildfly/:/opt/jboss/wildfly/standalone/log/ \
                         -v /home/centos/standalone.xml:/opt/jboss/wildfly/standalone/configuration/standalone.xml \
                         -v /home/centos/fence_mapping.json:/usr/local/docker-config/fence_mapping.json \
                         -v /home/centos/aggregate-resource.properties:/opt/jboss/wildfly/standalone/configuration/aggregate-data-sharing/pic-sure-aggregate-resource/resource.properties \
-                        -v /var/log/wildfly-docker-os-logs/:/var/log/ \
                         -v /home/centos/visualization-resource.properties:/opt/jboss/wildfly/standalone/configuration/visualization/pic-sure-visualization-resource/resource.properties \
                         -p 8080:8080 -e JAVA_OPTS="$JAVA_OPTS" -d $WILDFLY_IMAGE

--- a/app-infrastructure/scripts/wildfly-docker.sh
+++ b/app-infrastructure/scripts/wildfly-docker.sh
@@ -26,7 +26,7 @@ JAVA_OPTS="-Xms2g -Xmx24g -XX:MetaspaceSize=96M -XX:MaxMetaspaceSize=1024m -Djav
 sudo docker run -u root --name=wildfly --network=picsure \
                         --restart unless-stopped \
                         --log-opt tag=wildfly \
-                        -v /var/log/wildfly/:/opt/jboss/wildfly/standalone/log/ \
+                        -v /var/log/picsure/wildfly/:/opt/jboss/wildfly/standalone/log/ \
                         -v /home/centos/standalone.xml:/opt/jboss/wildfly/standalone/configuration/standalone.xml \
                         -v /home/centos/fence_mapping.json:/usr/local/docker-config/fence_mapping.json \
                         -v /home/centos/aggregate-resource.properties:/opt/jboss/wildfly/standalone/configuration/aggregate-data-sharing/pic-sure-aggregate-resource/resource.properties \

--- a/app-infrastructure/scripts/wildfly-user_data.sh
+++ b/app-infrastructure/scripts/wildfly-user_data.sh
@@ -4,8 +4,6 @@ echo "SPLUNK_INDEX=hms_aws_${gss_prefix}" | sudo tee /opt/srce/startup.config
 echo "NESSUS_GROUP=${gss_prefix}_${target_stack}" | sudo tee -a /opt/srce/startup.config
 
 sudo sh /opt/srce/scripts/start-gsstools.sh
-sudo systemctl stop SplunkForwarder
-/opt/splunkforwarder/bin/splunk enable boot-start -systemd-managed 1 -user splunk  || true
 
 s3_copy() {
   for i in {1..5}; do
@@ -25,7 +23,7 @@ sudo swapon /swapfile
 
 # make picsure network
 sudo docker network create picsure
-sudo mkdir -p /var/log/{wildfly,psama}
+sudo mkdir -p /var/log/picsure/{wildfly,psama}
 
 # Download the wildfly and psama docker scripts
 s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/wildfly-docker.sh /home/centos/wildfly-docker.sh
@@ -49,8 +47,5 @@ sudo /home/centos/dictionary-docker.sh "$stack_s3_bucket"
 INSTANCE_ID=$(curl -H "X-aws-ec2-metadata-token: $(curl -X PUT "http://169.254.169.254/latest/api/token" -H "X-aws-ec2-metadata-token-ttl-seconds: 21600")" --silent http://169.254.169.254/latest/meta-data/instance-id)
 sudo /usr/bin/aws --region=us-east-1 ec2 create-tags --resources $${INSTANCE_ID} --tags Key=InitComplete,Value=true
 
-
-echo "Restart splunkforwarder service"
-sudo systemctl restart SplunkForwarder
 echo "user-data progress starting update"
 sudo yum -y update

--- a/app-infrastructure/scripts/wildfly-user_data.sh
+++ b/app-infrastructure/scripts/wildfly-user_data.sh
@@ -4,31 +4,7 @@ echo "SPLUNK_INDEX=hms_aws_${gss_prefix}" | sudo tee /opt/srce/startup.config
 echo "NESSUS_GROUP=${gss_prefix}_${target_stack}" | sudo tee -a /opt/srce/startup.config
 
 sudo sh /opt/srce/scripts/start-gsstools.sh
-
-echo "
-[monitor:///var/log/wildfly-docker-logs]
-sourcetype = hms_app_logs
-source = wildfly_logs
-index=hms_aws_${gss_prefix}
-
-[monitor:///var/log/wildfly-docker-os-logs]
-sourcetype = hms_app_logs
-source = wildfly_logs
-index=hms_aws_${gss_prefix}
-
-[monitor:///var/log/psama-docker-logs]
-sourcetype = hms_app_logs
-source = wildfly_logs
-index=hms_aws_${gss_prefix}
-
-[monitor:///var/log/psama-docker-os-logs]
-sourcetype = hms_app_logs
-source = wildfly_logs
-index=hms_aws_${gss_prefix}
-" | sudo tee -a /opt/splunkforwarder/etc/system/local/inputs.conf
-
 sudo systemctl stop SplunkForwarder
-
 /opt/splunkforwarder/bin/splunk enable boot-start -systemd-managed 1 -user splunk  || true
 
 s3_copy() {

--- a/app-infrastructure/scripts/wildfly-user_data.sh
+++ b/app-infrastructure/scripts/wildfly-user_data.sh
@@ -25,7 +25,7 @@ sudo swapon /swapfile
 
 # make picsure network
 sudo docker network create picsure
-sudo mkdir /var/log/{wildfly-docker-logs,wildfly-docker-os-logs,psama-docker-logs,psama-docker-os-logs}
+sudo mkdir -p /var/log/{wildfly,psama}
 
 # Download the wildfly and psama docker scripts
 s3_copy s3://${stack_s3_bucket}/configs/jenkins_pipeline_build_${stack_githash}/wildfly-docker.sh /home/centos/wildfly-docker.sh


### PR DESCRIPTION
- Removed `--syslog` docker flag from all containers. This change removes the docker logs from the `/var/log/messages`.
- Remove generation Splunk `input.conf` file. This is now maintain in Splunk Cloud by the HMS-IT team.
- Standardize all logging directories. The naming convention now uses `/var/log/picsure/{container_name}`.